### PR TITLE
Disable multiple devices support

### DIFF
--- a/tfdml/core/dml_device_cache.cc
+++ b/tfdml/core/dml_device_cache.cc
@@ -283,7 +283,7 @@ DmlDeviceCache::DmlDeviceCache()
             "The first available device in order of performance was selected "
             "by default. To select a different device, set the "
             "DML_VISIBLE_DEVICES environment variable to its index (e.g. "
-            "DML_VISIBLE_DEVICES=\"1\").");
+            "DML_VISIBLE_DEVICES=1).");
 
         adapters_ = {adapters[0]};
     }


### PR DESCRIPTION
Cross-device copies currently don't work, so until we understand the best way to fix it, we should disable multiple DML devices usage.