### PR TITLE
Add workaround to DataFormatDimMap's validation

### DIFF
--- a/tfdml/kernels/dml_data_format_dim_map.cc
+++ b/tfdml/kernels/dml_data_format_dim_map.cc
@@ -110,14 +110,6 @@ class DmlDataFormaDimMapKernel : public DmlKernel
                 "Source format must be of length 4 or 5, received "
                 "src_format = ",
                 src_format)));
-
-        OP_REQUIRES(
-            ctx->GetOpKernelContext(),
-            src_format.size() == 4 || src_format.size() == 5,
-            errors::InvalidArgument(absl::StrCat(
-                "Source format must be of length 4 or 5, received "
-                "src_format = ",
-                src_format)));
         OP_REQUIRES(
             ctx->GetOpKernelContext(),
             dst_format.size() == 4 || dst_format.size() == 5,


### PR DESCRIPTION
Putting DataFormatDimMap's validation inside the OpKernel's constructor works, but it somehow makes other ops fail by having the wrong inputs. After testing with simple dummy ops, it seems that the issue comes from TensorFlow Core itself where it may be handling DataFormatDimMap in a special way for grappler purposes. This ideally needs more investigation, but since the workaround of putting the validation in the Compute function doesn't cost us anything, this is low priority.