### PR TITLE
Remove TODOs inherited from the TensorFlow codebase

### DIFF
--- a/test/ops/array_ops_test.py
+++ b/test/ops/array_ops_test.py
@@ -415,7 +415,6 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
 
   # This is the version of reverse that uses axis indices rather than
   # bool tensors
-  # TODO(b/32254538): Change this test to use array_ops.reverse
   #
   # Note: this test passes placeholder as constant axis is validated
   # in shape function (see testInvalidAxis)
@@ -739,8 +738,6 @@ class StridedSliceTest(test_util.TensorFlowTestCase):
       f = func.get_concrete_function(
           tensor_spec.TensorSpec([2, 2], dtypes.int16))
 
-      # TODO(b/190416665): Allow the constant to be eagerly copied/created on
-      # the GPU.
       with ops.device("CPU"):
         ones = constant_op.constant([[1, 1], [1, 1]], dtypes.int16)
       self.assertAllEqual([[1, 1]], self.evaluate(f(ones)))
@@ -1558,7 +1555,6 @@ class InvertPermutationTest(test_util.TensorFlowTestCase):
 
 class UnravelIndexTest(test_util.TensorFlowTestCase):
 
-  # TODO(b/73086570): Reenable test.
   @unittest.skip("Test does not pass internally.")
   def testUnravelIndex(self):
     with self.cached_session():
@@ -1700,7 +1696,6 @@ class QuantizeAndDequantizeTest(test_util.TensorFlowTestCase):
     # XLA raises an UnimplementedError on invalid axis.
     error_message_pattern = (r"Shape must be at least rank 11 but is rank "
                              r"1|invalid axis")
-    # TODO(b/171260356): Eager mode and graph mode throw different error types
     error = (errors.InvalidArgumentError, ValueError, errors.UnimplementedError)
     with self.assertRaisesRegex(error, error_message_pattern):
       self.evaluate(
@@ -2328,8 +2323,6 @@ class StopGradientTest(test_util.TensorFlowTestCase):
     with backprop.GradientTape() as tape:
       y = array_ops.stop_gradient(x)
 
-    # TODO(b/202162002): Once GradientTape supports composiste tensors, use
-    # tape.gradient(y, x).
     self.assertIsNone(tape.gradient(y.values, x.values))
 
 

--- a/test/ops/bias_op_deterministic_test.py
+++ b/test/ops/bias_op_deterministic_test.py
@@ -130,8 +130,6 @@ class BiasAddDeterministicTest(bias_op_base.BiasAddTestBase,
           result_b = bias_gradients.eval(feed_dict=feed_dict)
           self.assertAllEqual(result_a, result_b)
 
-  # TODO(duncanriach): Re-enable the following three tests for the error checks
-  #   after deterministic functionality is implemented at the CUDA kernel level.
   def testInputDims(self):
     pass
 
@@ -143,6 +141,5 @@ class BiasAddDeterministicTest(bias_op_base.BiasAddTestBase,
 
 
 if __name__ == '__main__':
-  # TODO(reedwm): Merge this file with bias_op_base.py and bias_op_test.py
   config.enable_op_determinism()
   test.main()

--- a/test/ops/concat_op_test.py
+++ b/test/ops/concat_op_test.py
@@ -392,7 +392,6 @@ class ConcatOpTest(test.TestCase):
               x0 = np.random.randn(*(shape0 + (n0,) + shape1))
               x1 = np.random.randn(*(shape0 + (n1,) + shape1))
               correct = np.concatenate([x0, x1], axis=axis)
-              # TODO(irving): Make tf.concat handle map, then drop list().
               xs = list(map(constant_op.constant, [x0, x1]))
               c = array_ops.concat(xs, axis)
               self.assertAllEqual(self.evaluate(c), correct)

--- a/test/ops/conv_ops_3d_test.py
+++ b/test/ops/conv_ops_3d_test.py
@@ -505,9 +505,6 @@ class Conv3DTest(test.TestCase):
     filter_data = [x * 1.0 / filter_size for x in range(0, filter_size)]
 
     for data_type in self._DtypesToTest(use_gpu=use_gpu):
-      # TODO(mjanusz): Modify gradient_checker to also provide max relative
-      # error and synchronize the tolerance levels between the tests for forward
-      # and backward computations.
       if data_type == dtypes.float64:
         tolerance = 1e-8
       elif data_type == dtypes.float32:

--- a/test/ops/conv_ops_test.py
+++ b/test/ops/conv_ops_test.py
@@ -890,7 +890,6 @@ class Conv2DTest(test.TestCase):
             data_format=data_format,
             use_gpu=True,
             max_err=0.005)
-  # TODO(yzhwang): this currently fails.
   # self._VerifyValues(tensor_in_sizes=[1, 8, 8, 1],
   #                   filter_in_sizes=[2, 2, 1, 1],
   #                   strides=[4, 4], padding="SAME",
@@ -1867,7 +1866,6 @@ class Conv2DTest(test.TestCase):
     assert in_depth % num_groups == 0 and out_depth % num_groups == 0
     input_shape = [batch, input_rows, input_cols, in_depth]
     filter_shape = [filter_rows, filter_cols, in_depth // num_groups, out_depth]
-    # TODO(yangke): re-factor the computation of output shape.
     if padding == "VALID":
       output_rows = (input_rows - filter_rows + stride_rows) // stride_rows
       output_cols = (input_cols - filter_cols + stride_cols) // stride_cols
@@ -2540,7 +2538,6 @@ class Conv2DTest(test.TestCase):
           nn_ops.conv2d(
               input_val, filter_val, strides=[1, 1, 1, 2], padding="SAME"))
 
-    # TODO(b/195689143): Will enable when fixed for V2 behavior
     # # Filter larger than input.
     # with self.assertRaisesRegex(ValueError, "Negative dimension size"):
     #   input_val = np.ones([32, 20, 20, 3])
@@ -3079,7 +3076,6 @@ class Conv2DBenchmark(test.Benchmark):
     fact the Python padding list must be checked and processed before the Conv2D
     op can run.
     """
-    # TODO(reedwm): Make EXPLICIT padding as fast as SAME padding.
     if not test.is_gpu_available():
       return
 
@@ -3404,12 +3400,6 @@ if __name__ == "__main__":
                                            output_size_, [stride_, stride_],
                                            padding_)))
 
-  # TODO(b/35359731)
-  # Fwd, BckInput, and BackFilter to test that for certain input parameter
-  # set, winograd nonfused algorithm will be excluded from conv autotune. If
-  # in such case, winograd nonfused algorithm is added as one option of the
-  # conv autotune, and cuDNN version is smaller than 7, the following tests
-  # will fail.
   ishape = [1, 400, 400, 1]
   fshape = [1, 1, 1, 256]
   oshape = [1, 400, 400, 256]

--- a/test/ops/cwise_ops_binary_test.py
+++ b/test/ops/cwise_ops_binary_test.py
@@ -40,8 +40,6 @@ _FLOORDIV = lambda x, y: x // y
 _MOD = lambda x, y: x % y
 
 
-# TODO(zongheng): it'd be great to factor out this function and various random
-# SparseTensor gen funcs.
 def _sparsify(x, thresh=0.5, index_dtype=np.int64):
   x[x < thresh] = 0
 
@@ -179,7 +177,6 @@ class BinaryOpTest(test.TestCase):
     else:
       self.assertAllClose(np_ans, tf_gpu)
     self.assertShapeEqual(np_ans, out)
-    # TODO(zhifengc/ke): make gradient checker work on GPU.
 
   def _compareBoth(self, x, y, np_func, tf_func, also_compare_variables=False):
     self._compareCpu(x, y, np_func, tf_func, also_compare_variables)
@@ -421,8 +418,6 @@ class BinaryOpTest(test.TestCase):
       y = (1 + np.linspace(0, 5, np.prod(ys))).astype(dtype).reshape(ys)
     self._compareCpu(x, y, np_func, tf_func)
     if x.dtype in (np.float16, np.float32, np.float64):
-      # TODO(aselle): Make the test work for dtypes:
-      #     (np.complex64, np.complex128).
       if tf_func not in (_FLOORDIV, math_ops.floordiv):
         if x.dtype == np.float16:
           # Compare fp16 theoretical gradients to fp32 numerical gradients,
@@ -437,7 +432,6 @@ class BinaryOpTest(test.TestCase):
           self._compareGradientY(x, y, np_func, tf_func)
       self._compareGpu(x, y, np_func, tf_func)
 
-  # TODO(josh11b,vrv): Refactor this to use parameterized tests.
   def _testBCastByFunc(self, funcs, xs, ys):
     dtypes = [
         np.float16,

--- a/test/ops/cwise_ops_test.py
+++ b/test/ops/cwise_ops_test.py
@@ -47,8 +47,6 @@ _XOR = lambda x, y: x ^ y
 _INV = lambda x: ~x
 
 
-# TODO(zongheng): it'd be great to factor out this function and various random
-# SparseTensor gen funcs.
 def _sparsify(x, thresh=0.5, index_dtype=np.int64):
   x[x < thresh] = 0
 
@@ -1065,7 +1063,6 @@ class RoundingTest(test.TestCase):
   def _testDtype(self, dtype):
     data = (np.arange(-3, 3) / 4.).reshape(1, 3, 2).astype(dtype)
     self._compare(data)
-    # TODO(reedwm): rint op is not supported for float16 and bfloat16
     if dtype in (np.float16, dtypes_lib.bfloat16.as_numpy_dtype):
       return
     self._compare_values(data)

--- a/test/ops/cwise_ops_unary_test.py
+++ b/test/ops/cwise_ops_unary_test.py
@@ -37,8 +37,6 @@ _NEG = lambda x: -x
 _ABS = abs
 
 
-# TODO(zongheng): it'd be great to factor out this function and various random
-# SparseTensor gen funcs.
 def _sparsify(x, thresh=0.5, index_dtype=np.int64):
   x[x < thresh] = 0
 

--- a/test/ops/depthwise_conv_op_test.py
+++ b/test/ops/depthwise_conv_op_test.py
@@ -670,9 +670,6 @@ class DepthwiseConv2DTest(test.TestCase):
           err = gradient_checker.compute_gradient_error(
               filter_tensor, filter_shape, depthwise_conv2d, output_shape)
       except errors.InvalidArgumentError as e:
-        # TODO(xjun): Tests depend on error messages could be brittle.
-        # Grouped convolution kernel is only registered for cuDNN 7. Silently
-        # return when we are running on an earlier version or without GPU.
         if grouped_conv and ("No OpKernel was registered to support Op "
                              "'DepthwiseConv2dNative'") in e.message:
           tf_logging.warn("Skipping grouped convolution test")

--- a/test/ops/gather_nd_op_test.py
+++ b/test/ops/gather_nd_op_test.py
@@ -213,8 +213,6 @@ class GatherNdTest(test.TestCase):
         self.evaluate(gather_nd)
 
   def _disabledTestBadIndicesGPU(self):
-    # TODO disabled due to different behavior on GPU and CPU
-    # On GPU the bad indices do not raise error but fetch 0 values
     if not test.is_gpu_available():
       return
     with self.session():
@@ -237,8 +235,6 @@ class GatherNdTest(test.TestCase):
         self.evaluate(gather_nd)
 
   def _disabledTestBadIndicesWithSlicesGPU(self):
-    # TODO disabled due to different behavior on GPU and CPU
-    # On GPU the bad indices do not raise error but fetch 0 values
     if not test.is_gpu_available():
       return
     with self.session():

--- a/test/ops/gather_op_test.py
+++ b/test/ops/gather_op_test.py
@@ -37,8 +37,6 @@ from tensorflow.python.platform import test
 
 _TEST_TYPES = (dtypes.int64, dtypes.float32,)
 
-# TODO(virimia): Add a benchmark for gather_v2, with batch_dims and axis set.
-
 
 def _to_str_elements(values):
   """Converts the inner list elements to strings."""
@@ -301,8 +299,6 @@ class GatherTest(test.TestCase, parameterized.TestCase):
         self.evaluate(array_ops.gather(params, [[7]], axis=1))
 
   def _disabledTestBadIndicesGPU(self):
-    # TODO disabled due to different behavior on GPU and CPU
-    # On GPU the bad indices do not raise error but fetch 0 values
     if not test.is_gpu_available():
       return
     with self.session():

--- a/test/ops/image_grad_deterministic_test.py
+++ b/test/ops/image_grad_deterministic_test.py
@@ -367,7 +367,5 @@ class CropAndResizeOpDeterministicTest(test_base.CropAndResizeOpTestBase):
 
 
 if __name__ == '__main__':
-  # TODO(reedwm): Merge this file with image_grad_test.py and
-  # image_grad_test_base.py
   config.enable_op_determinism()
   test.main()

--- a/test/ops/image_ops_test.py
+++ b/test/ops/image_ops_test.py
@@ -1096,9 +1096,6 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase,
       self.assertEqual(count_flipped, 45)
       self.assertEqual(count_unflipped, 55)
 
-  # TODO(b/162345082): stateless random op generates different random number
-  # with xla_gpu. Update tests such that there is a single ground truth result
-  # to test against.
   @parameterized.named_parameters(
       ("_RandomFlipLeftRight", image_ops.stateless_random_flip_left_right),
       ("_RandomFlipUpDown", image_ops.stateless_random_flip_up_down),
@@ -1143,9 +1140,6 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase,
         self.assertAllEqual(flip_counts[0], flip_counts[i])
         self.assertAllEqual(flip_sequences[0], flip_sequences[i])
 
-  # TODO(b/162345082): stateless random op generates different random number
-  # with xla_gpu. Update tests such that there is a single ground truth result
-  # to test against.
   @parameterized.named_parameters(
       ("_RandomFlipLeftRight", image_ops.stateless_random_flip_left_right),
       ("_RandomFlipUpDown", image_ops.stateless_random_flip_up_down)
@@ -2293,7 +2287,6 @@ class PadToBoundingBoxTest(test_util.TensorFlowTestCase,
   def testInvalidInput(self):
     # Test case for GitHub issue 46890.
     if test_util.is_xla_enabled():
-      # TODO(b/200850176): test fails with XLA.
       return
     with self.session():
       with self.assertRaises(errors_impl.InvalidArgumentError):
@@ -2379,14 +2372,6 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
     #                                     range=aspect_ratio_range)
     # mean = np.mean(aspect_ratio_hist)
     # stddev = np.sqrt(mean)
-    # TODO(wicke, shlens, dga): Restore this test so that it is no longer flaky.
-    # TODO(irving): Since the rejection probability is not independent of the
-    # aspect ratio, the aspect_ratio random value is not exactly uniformly
-    # distributed in [min_aspect_ratio, max_aspect_ratio).  This test should be
-    # fixed to reflect the true statistical property, then tightened to enforce
-    # a stricter bound.  Or, ideally, the sample_distorted_bounding_box Op
-    # be fixed to not use rejection sampling and generate correctly uniform
-    # aspect ratios.
     # self.assertAllClose(aspect_ratio_hist,
     #                     [mean] * num_bins, atol=3.6 * stddev)
 
@@ -2402,7 +2387,6 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
     print("area_ratio_hist ", area_ratio_hist)
 
     # Ensure that fraction_object_covered is satisfied.
-    # TODO(wicke, shlens, dga): Restore this test so that it is no longer flaky.
     # self.assertGreaterEqual(min(fraction_object_covered), min_object_covered)
 
   def testWholeImageBoundingBox(self):
@@ -2567,9 +2551,6 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
         self.assertEqual(len(set(area_ratios)), 1)
         self.assertEqual(len(set(fraction_object_covered)), 1)
 
-  # TODO(b/162345082): stateless random op generates different random number
-  # with xla_gpu. Update tests such that there is a single ground truth result
-  # to test against.
   def testWholeImageBoundingBoxStateless(self):
     height = 40
     width = 50
@@ -2585,9 +2566,6 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
           aspect_ratio_range=(0.75, 1.33),
           area_range=(0.05, 1.0))
 
-  # TODO(b/162345082): stateless random op generates different random number
-  # with xla_gpu. Update tests such that there is a single ground truth result
-  # to test against.
   def testWithBoundingBoxStateless(self):
     height = 40
     width = 50
@@ -3528,8 +3506,6 @@ class ResizeImagesTest(test_util.TensorFlowTestCase,
         6.0, 6.0, 3.0, 3.0, 3.0, 3.0, 6.0, 6.0, 3.0, 3.0, 6.0, 6.0, 6.0, 6.0,
         9.0, 9.0, 6.0, 6.0, 9.0, 9.0
     ]
-    # TODO(b/37749740): Improve alignment of ResizeMethodV1.AREA when
-    # align_corners=True.
     expected_data[image_ops.ResizeMethodV1.AREA] = [
         6.0, 6.0, 6.0, 3.0, 6.0, 6.0, 6.0, 3.0, 3.0, 3.0, 3.0, 6.0, 3.0, 3.0,
         3.0, 6.0, 6.0, 6.0, 6.0, 9.0
@@ -4259,7 +4235,6 @@ def simple_color_ramp():
 
 class JpegTest(test_util.TensorFlowTestCase):
 
-  # TODO(irving): Add self.assertAverageLess or similar to test_util
   def averageError(self, image0, image1):
     self.assertEqual(image0.shape, image1.shape)
     image0 = image0.astype(int)  # Avoid overflow
@@ -4448,9 +4423,6 @@ class JpegTest(test_util.TensorFlowTestCase):
               np.array_equal(random_jpeg_images[0], random_jpeg_images[i]))
         self.assertFalse(all(are_images_equal))
 
-  # TODO(b/162345082): stateless random op generates different random number
-  # with xla_gpu. Update tests such that there is a single ground truth result
-  # to test against.
   def testStatelessRandomJpegQuality(self):
     # Test deterministic randomness in jpeg quality by checking that the same
     # sequence of jpeg quality adjustments are returned each round given the
@@ -4808,7 +4780,6 @@ class TotalVariationTest(test_util.TensorFlowTestCase):
 
     return a
 
-  # TODO(b/133851381): re-enable this test.
   def disabledtestTotalVariationNumpy(self):
     """Test the TensorFlow implementation against a numpy implementation.
     The two implementations are very similar so it is possible that both

--- a/test/ops/matmul_op_test.py
+++ b/test/ops/matmul_op_test.py
@@ -32,9 +32,6 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test as test_lib
 
-# TODO(yangzihao): Currently matmul autotuning is disabled by default. Use
-# os.environ["TF_MATMUL_AUTOTUNE_ENABLE"] = "1" to enable it.
-
 
 class MatVecTest(test_lib.TestCase):
   """Simple test for matvec, which is sugar on top of matmul."""
@@ -233,8 +230,6 @@ if __name__ == "__main__":
   for use_static_shape in set([True, tf2.enabled()]):
     for dtype in dtypes_to_test:
       if not use_static_shape and (dtype == np.int32 or dtype == np.int64):
-        # TODO(rmlarsen): Re-enable this test when we have fixed the underlying
-        # bug in Windows (b/35935459).
         continue
       for m in sizes:
         for n in sizes:

--- a/test/ops/nn_fused_batchnorm_test.py
+++ b/test/ops/nn_fused_batchnorm_test.py
@@ -36,7 +36,6 @@ class BatchNormalizationTest(test.TestCase):
   def _batch_norm(self, x, mean, var, offset, scale, epsilon):
     # We compute the batch norm manually in this function because
     # nn_impl.batch_normalization does not support float16 yet.
-    # TODO(reedwm): Add float16 support to nn_impl.batch_normalization.
     inv = math_ops.rsqrt(var + epsilon) * scale
     y = math_ops.cast(x, scale.dtype) * inv + (offset - mean * inv)
     return math_ops.cast(y, x.dtype)
@@ -206,8 +205,6 @@ class BatchNormalizationTest(test.TestCase):
     x_init_val = np.random.random_sample(x_shape).astype(np.float16)
     x32_init_val = x_init_val.astype(np.float32)
 
-    # TODO(reedwm): Do not perform the unnecessary computations in
-    # compute_gradient, since they double the computation time of this function.
     theoretical_grad, _ = gradient_checker.compute_gradient(
         x, x_shape, y, y_shape, delta=1e-3, x_init_value=x_init_val)
     _, numerical_grad = gradient_checker.compute_gradient(

--- a/test/ops/pad_op_test.py
+++ b/test/ops/pad_op_test.py
@@ -268,8 +268,6 @@ class PadOpTest(test.TestCase):
           np.array(123).astype(t))
 
   def testIntTypes(self):
-    # TODO(touts): Figure out why the padding tests do not work on GPU
-    # for int types and rank > 2.
     for t in [np.int8, np.uint8, np.int32, np.int64]:
       self._testAll(
           np.random.randint(-100, 100, (4, 4, 3)).astype(t),

--- a/test/ops/pooling_ops_3d_test.py
+++ b/test/ops/pooling_ops_3d_test.py
@@ -43,7 +43,6 @@ def GetTestConfigs():
   return test_configs
 
 
-# TODO(mjanusz): Add microbenchmarks for 3d pooling.
 @test_util.with_eager_op_as_function
 class PoolingTest(test.TestCase):
 

--- a/test/ops/pooling_ops_test.py
+++ b/test/ops/pooling_ops_test.py
@@ -48,8 +48,6 @@ def GetDeviceScope(self, use_gpu=False):
     return self.session(use_gpu=use_gpu)
 
 
-# TODO(jlebar): Convert the rest of this file to parameters.parameterized().
-# Then remove GetTestConfigs() and rename GetTestConfigsDicts().
 def GetTestConfigsDicts(v1_fn,
                         v2_fn=None,
                         one_dimensional=False,

--- a/test/ops/resource_variable_ops_test.py
+++ b/test/ops/resource_variable_ops_test.py
@@ -352,7 +352,6 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
 
     c = constant_op.constant(1.)
     identity = array_ops.identity_n([c, v.handle])
-    # TODO(b/137403775): Remove this.
     handle_data_util.copy_handle_data(v.handle, identity[1])
 
     g = gradients_impl.gradients(identity[0], [c, v.handle])
@@ -737,7 +736,6 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     self.assertEqual(
         compat.as_bytes(self.evaluate(read)[0][0]), compat.as_bytes("b"))
 
-  # TODO(alive): get this to work in Eager mode.
   def testGPU(self):
     with test_util.use_gpu():
       abc = variable_scope.get_variable(
@@ -775,7 +773,6 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
       v = resource_variable_ops.ResourceVariable(
           initial_value=lambda: 1, constraint=constraint, name="var1")
 
-  # TODO(alive): how should this work in Eager mode?
   @test_util.run_deprecated_v1
   def testInitFn(self):
     with self.cached_session():
@@ -1136,7 +1133,6 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     self.assertIsInstance(w.dtype, dtypes.DType)
     self.assertEqual(v.dtype, w.dtype)
 
-  # TODO(alive): get caching to work in eager mode.
   @test_util.run_deprecated_v1
   def testCachingDevice(self):
     with ops.device("/job:server/task:1"):
@@ -1487,8 +1483,6 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
             ]))
     return value
 
-  # TODO(ebrevdo): Add run_in_graph_and_eager_modes once we can create
-  # EagerTensor constants with TensorProto inputs.
   @test_util.disable_tfrt("Does not support tf.Const in lowering.")
   @test_util.run_in_graph_and_eager_modes()
   def testVariantInitializer(self):
@@ -1648,10 +1642,7 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
   @test_util.run_v2_only
   def testUninitializedVariableMemoryUsage(self):
     if test_util.is_gpu_available():
-      # TODO(allenl): Investigate possible GPU-specific memory leaks
       self.skipTest("Disabled when a GPU is available")
-    # TODO(kkb): Python memory checker complains continuous `weakref`
-    # allocations, investigate.
     if memory_checker.CppMemoryChecker is None:
       self.skipTest("Requires the C++ memory checker")
 

--- a/test/ops/stack_op_test.py
+++ b/test/ops/stack_op_test.py
@@ -168,7 +168,6 @@ class StackOpTest(test.TestCase):
 
           def func(*xs):
             return array_ops.stack(xs)
-          # TODO(irving): Remove list() once we handle maps correctly
           xs = list(map(constant_op.constant, data))
           theoretical, numerical = gradient_checker_v2.compute_gradient(
               func, xs)
@@ -185,7 +184,6 @@ class StackOpTest(test.TestCase):
 
           def func(*inp):
             return array_ops.stack(inp, axis=1)
-          # TODO(irving): Remove list() once we handle maps correctly
           xs = list(map(constant_op.constant, data))
           theoretical, numerical = gradient_checker_v2.compute_gradient(
               func, xs)

--- a/test/ops/training_eager_test.py
+++ b/test/ops/training_eager_test.py
@@ -192,8 +192,6 @@ class TrainingTest(keras_parameterized.TestCase):
       model.fit(dataset, steps_per_epoch=2, epochs=1, verbose=0,
                 validation_data=validation_dataset)
 
-  # TODO(b/120931266): Enable test on subclassed models after bug causing an
-  # extra dimension to be added to predict outputs is fixed.
   @keras_parameterized.run_with_all_model_types(exclude_models='subclass')
   def test_generator_methods(self):
     model = testing_utils.get_small_mlp(10, 4, 3)

--- a/test/ops/xent_op_test_base.py
+++ b/test/ops/xent_op_test_base.py
@@ -54,8 +54,6 @@ class XentOpTestBase(test.TestCase):
     l = -np.sum(labels * np.log(probs + 1.0e-20), axis=dim)
     return l, bp
 
-  # TODO(b/123860949): The values are constant folded for XLA, so placeholders
-  # are needed.
   def _testXent2D(self,
                   np_labels,
                   np_logits,
@@ -135,8 +133,6 @@ class XentOpTestBase(test.TestCase):
     self.assertAllClose(
         np.array([1.3862, 1.9401]), np_loss, rtol=1.e-3, atol=1.e-3)
 
-  # TODO(b/123860949): The values are constant folded for XLA, so placeholders
-  # are needed.
   @test_util.run_deprecated_v1
   def _testLabelsBroadcast(self, uniform_labels_gradient):
     labels = np.array([[0., 0., 0., 1.]]).astype(np.float16)

--- a/tfdml/kernels/dml_strided_slice_op.cc
+++ b/tfdml/kernels/dml_strided_slice_op.cc
@@ -240,8 +240,6 @@ Status ValidateStridedSliceOp(
     // Step 1: Account for ellipsis and new axis
     //
     // Check for ellipses and count how many non-newaxis' there are after
-    // TODO(aselle): Convert this to do a fast log2 followed by iteration
-    //               counting ones in next guys
     bool ellipsis_seen = false;
 
     StridedSliceSparseSpec sparse_spec = {

--- a/tfdml/runtime_adapter/bcast.h
+++ b/tfdml/runtime_adapter/bcast.h
@@ -96,8 +96,6 @@ inline void ComputeBatchIndices(
 //
 // The multiplication in the grad * backprop_x itself is also
 // broadcasting following the same rule.
-//
-// TODO(zhifengc): Adds support for n-ary (n >= 2).
 class BCast
 {
   public:

--- a/tfdml/runtime_adapter/fused_eigen_output_kernels.cc
+++ b/tfdml/runtime_adapter/fused_eigen_output_kernels.cc
@@ -43,9 +43,6 @@ Status InitializeFusedComputation(
     int num_args;
     TF_RETURN_IF_ERROR(context->GetAttr("num_args", &num_args));
 
-    // TODO(ezhulenev): Add support for fusion element-wise op chains defined
-    // at runtime, e.g. Relu+Sqrt+Tanh+etc.
-
     // Reset fused computation type.
     *fused_computation = FusedComputationType::kUndefined;
 

--- a/tfdml/runtime_adapter/kernel_shape_util.h
+++ b/tfdml/runtime_adapter/kernel_shape_util.h
@@ -101,8 +101,6 @@ Status GetWindowedOutputSize(
 //
 // If you want to use EXPLICIT padding, GetWindowedOutputSizeVerboseV2 must be
 // called instead
-//
-// TODO(b/67112639): Merge V2 versions and the original versions eventually.
 Status GetWindowedOutputSizeV2(
     int64_t input_size,
     int64_t filter_size,

--- a/tfdml/runtime_adapter/tensor_format.h
+++ b/tfdml/runtime_adapter/tensor_format.h
@@ -25,9 +25,6 @@ namespace tfdml
 // The mnemonics specify the meaning of each tensor dimension sorted from
 // largest to smallest memory stride.
 // N = Batch, H = Image Height, W = Image Width, C = Number of Channels.
-// TODO(pauldonnelly): It would probably be better to switch to a registration
-// process for tensor formats, so specialized formats could be defined more
-// locally to where they are used.
 enum TensorFormat
 {
     // FORMAT_NHWC is the default format in TensorFlow.
@@ -313,10 +310,6 @@ inline int GetFilterTensorOutputChannelsDimIndex(
         return -1; // Avoid compiler warning about missing return value
     }
 }
-
-// TODO(pauldonnelly): Replace these tensor dimension index functions with
-// constant structs to improve performance and reduce code size in Compute()
-// functions.
 
 // Return the dimension index for the specified 'dimension' of the specified
 // data 'tensor_format'.  'dimension' is a char that can be 'N' (batch size),


### PR DESCRIPTION
Those are not TODOs that we can act on and they make our own TODOs harder to find.