### PR TITLE
Freeze keras

### DIFF
--- a/pipelines/create_test_env.ps1
+++ b/pipelines/create_test_env.ps1
@@ -4,7 +4,8 @@ param
 (
     [string]$ArtifactsDirectory = $env:SYSTEM_ARTIFACTSDIRECTORY,
     [Parameter(Mandatory)][string]$TestArtifactPath,
-    [Parameter(Mandatory)][string]$TensorFlowPackage
+    [Parameter(Mandatory)][string]$TensorFlowPackage,
+    [Parameter(Mandatory)][string]$KerasPackage
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,6 +26,7 @@ Start-Process $DownloadPath -ArgumentList '/NoRegistry=1', '/InstallationType=Ju
 conda create --prefix $TestEnvPath python=$PyVersionMajorDotMinor -y
 conda activate $TestEnvPath
 pip install $TensorFlowPackage
+pip install $KerasPackage
 pip install tensorboard_plugin_profile
 pip install $PluginPackage
 pip list

--- a/pipelines/create_test_env.sh
+++ b/pipelines/create_test_env.sh
@@ -5,6 +5,7 @@
 
 test_artifact_path=$1
 tensorflow_package=$2
+keras_package=$3
 
 # Windows agents use the agent artifacts directory for the conda installation, but
 # this is slow in WSL (filesystem networking overhead). Instead the agent will use
@@ -28,6 +29,7 @@ conda create --prefix $test_env_path python=$py_version_major_dot_minor -y
 
 conda activate $test_env_path
 pip install $tensorflow_package
+pip install $keras_package
 pip install tensorboard_plugin_profile
 pip install $plugin_package
 pip list

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -43,6 +43,11 @@ parameters:
   type: string
   default: tf-nightly-cpu==2.9.0.dev20220123
 
+- name: testKerasPackage
+  displayName: TensorFlow Package Version
+  type: string
+  default: keras-nightly==2.9.0.dev2022010508
+
 - name: enableTests
   displayName: Enable Tests
   type: boolean
@@ -79,6 +84,7 @@ stages:
         testGroups: ${{parameters.testGroups}}
         artifacts: ${{parameters.testArtifacts}}
         tensorflowPackage: ${{parameters.testTensorflowPackage}}
+        kerasPackage: ${{parameters.testKerasPackage}}
 
 - stage: reportStage
   displayName: Report Results

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -17,6 +17,9 @@ parameters:
 - name: tensorflowPackage
   type: string
   default: tf-nightly-cpu==2.9.0.dev20220123
+- name: kerasPackage
+  type: string
+  default: keras-nightly==2.9.0.dev2022010508
 - name: pluginBuildPipeline
   type: string
   default: current
@@ -131,7 +134,7 @@ jobs:
             $ScriptPathWsl = wsl wslpath -a $ScriptPath
             $TestArtifactPath = "$(buildArtifactsPathRoot)/${{artifact}}" -replace '\\','/'
             $TestArtifactPathWsl = wsl wslpath -a $TestArtifactPath
-            wsl bash $ScriptPathWsl $TestArtifactPathWsl ${{parameters.tensorflowPackage}}
+            wsl bash $ScriptPathWsl $TestArtifactPathWsl ${{parameters.tensorflowPackage}} ${{parameters.kerasPackage}}
 
       - task: PowerShell@2
         displayName: Test ${{artifact}}
@@ -162,6 +165,7 @@ jobs:
           arguments: >
             -TestArtifactPath $(buildArtifactsPathRoot)/${{artifact}}
             -TensorFlowPackage ${{parameters.tensorflowPackage}}
+            -KerasPackage ${{parameters.kerasPackage}}
 
       - task: PowerShell@2
         displayName: Test ${{artifact}}


### PR DESCRIPTION
Nightly builds of Keras frequently break, so we should freeze a known working version for the CI.