### PR TITLE
Dynamically enable the new AddN and ZerosLike variant ops

### DIFF
--- a/tfdml/runtime_adapter/op_kernel_context.h
+++ b/tfdml/runtime_adapter/op_kernel_context.h
@@ -122,13 +122,7 @@ class OpKernelContext
         Tensor* tensor);
     TF_OpKernelContext* raw() const;
 
-    bool AddNVariantSupported() const
-    {
-        // TODO: Uncomment if/when the API has been approved and once we have
-        // figured out the memory leak
-        // return TF_AddNVariant != nullptr;
-        return false;
-    }
+    bool AddNVariantSupported() const { return TF_AddNVariant != nullptr; }
 
     bool AssignRefVariableSupported() const
     {
@@ -137,10 +131,7 @@ class OpKernelContext
 
     bool ZerosLikeVariantSupported() const
     {
-        // TODO: Uncomment if/when the API has been approved and once we have
-        // figured out the memory leak
-        // return TF_ZerosLikeVariant != nullptr;
-        return false;
+        return TF_ZerosLikeVariant != nullptr;
     }
 
   private:


### PR DESCRIPTION
Today, Google has expressed interest in seeing a PR for `TF_AddNVariant` and `TF_ZerosLike` variant, so we should start testing them in the nightly benchmark pipeline to make sure that they're robust.