### PR TITLE
Increase default kernel max cache size to 1536

### DIFF
--- a/tfdml/core/dml_kernel_manager.h
+++ b/tfdml/core/dml_kernel_manager.h
@@ -51,7 +51,7 @@ class DmlKernelManager
   public:
     // Can be overridden by the TF_DIRECTML_KERNEL_CACHE_SIZE environment
     // variable
-    static constexpr size_t kDefaultMaxCacheSize = 1024;
+    static constexpr size_t kDefaultMaxCacheSize = 1536;
 
     DmlKernelManager();
 


### PR DESCRIPTION
We found out that big models like DeepLab were recompiling a lot of operators, which means that the cache wasn't big enough for this use case. With empirical testing, we found that increasing the cache size increased the performance by reducing the number of operator compilations.