### PR TITLE
Add caching for AddNVariant

### DIFF
--- a/tfdml/runtime_adapter/node_def.h
+++ b/tfdml/runtime_adapter/node_def.h
@@ -25,6 +25,22 @@ namespace tfdml
 class NodeDef
 {
   public:
+    NodeDef() = default;
+
+    NodeDef(
+        std::string_view op_name,
+        std::string_view op_type_name,
+        absl::InlinedVector<MemoryType, 8> tensor_memory_types,
+        absl::InlinedVector<AttributeValue, 4> attribute_values,
+        uint32_t input_tensor_count)
+        : op_name(op_name),
+          op_type_name(op_type_name),
+          tensor_memory_types(std::move(tensor_memory_types)),
+          attribute_values(std::move(attribute_values)),
+          input_tensor_count(input_tensor_count)
+    {
+    }
+
     inline std::string_view GetOpName() const { return op_name; }
 
     inline std::string_view GetOpTypeName() const { return op_type_name; }

--- a/tfdml/runtime_adapter/op_kernel_context.cc
+++ b/tfdml/runtime_adapter/op_kernel_context.cc
@@ -394,8 +394,8 @@ Status OpKernelContext::AssignRefVariable(
 
 Status OpKernelContext::AddNVariant(void (*binary_add_func)(
     TF_OpKernelContext* ctx,
-    const TF_Tensor* a,
-    const TF_Tensor* b,
+    TF_Tensor* a,
+    TF_Tensor* b,
     TF_Tensor* out))
 {
     Status status;
@@ -405,7 +405,7 @@ Status OpKernelContext::AddNVariant(void (*binary_add_func)(
 
 Status OpKernelContext::ZerosLikeVariant(void (*zeros_like_func)(
     TF_OpKernelContext* ctx,
-    const TF_Tensor* input,
+    TF_Tensor* input,
     TF_Tensor* out))
 {
     Status status;

--- a/tfdml/runtime_adapter/op_kernel_context.h
+++ b/tfdml/runtime_adapter/op_kernel_context.h
@@ -27,8 +27,8 @@ void TF_AddNVariantDeclaration(
     TF_OpKernelContext* ctx,
     void (*binary_add_func)(
         TF_OpKernelContext* ctx,
-        const TF_Tensor* a,
-        const TF_Tensor* b,
+        TF_Tensor* a,
+        TF_Tensor* b,
         TF_Tensor* out),
     TF_Status* status);
 
@@ -36,7 +36,7 @@ void TF_ZerosLikeVariantDeclaration(
     TF_OpKernelContext* ctx,
     void (*zeros_like_func)(
         TF_OpKernelContext* ctx,
-        const TF_Tensor* input,
+        TF_Tensor* input,
         TF_Tensor* out),
     TF_Status* status);
 
@@ -106,13 +106,13 @@ class OpKernelContext
 
     Status AddNVariant(void (*binary_add_func)(
         TF_OpKernelContext* ctx,
-        const TF_Tensor* a,
-        const TF_Tensor* b,
+        TF_Tensor* a,
+        TF_Tensor* b,
         TF_Tensor* out));
 
     Status ZerosLikeVariant(void (*zeros_like_func)(
         TF_OpKernelContext* ctx,
-        const TF_Tensor* input,
+        TF_Tensor* input,
         TF_Tensor* out));
 
     Status GetInputTensorFromVariable(


### PR DESCRIPTION
AddNVariant is a special kernel in the sense that it's a kernel that spawns other kernels. Currently, those other kernels are not cached so there can be a performance overhead since we need to recompile them every time. By leveraging the existing kernel manager and the existing cache, we can make our own lightweight kernel wrapper that will take care of caching and retrieving the AddV2 kernels spawned by AddNVariant.