### PR TITLE
Enable telemetry by default

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -40,7 +40,7 @@ parameters:
 - name: enableTelemetry
   displayName: Enable Telemetry
   type: boolean
-  default: false
+  default: true
 
 - name: testArtifacts
   displayName: Test Artifacts


### PR DESCRIPTION
Privacy review has been completed and telemetry has been approved, so we should enable it by default in the builds.