### PR TITLE
Fix remapper pt. 2 (#204)

### DIFF
--- a/tfdml/optimizer/graph_properties.cc
+++ b/tfdml/optimizer/graph_properties.cc
@@ -53,7 +53,13 @@ Status GraphProperties::InferStatically(
     bool include_output_tensor_values)
 {
     Status status;
-    TF_InferStatically(graph_props_, false, false, false, false, status.raw());
+    TF_InferStatically(
+        graph_props_,
+        assume_valid_feeds,
+        aggressive_shape_inference,
+        include_input_tensor_values,
+        include_output_tensor_values,
+        status.raw());
     TF_RETURN_IF_ERROR(status);
 
     for (int i = 0; i < item_.graph.node_size(); ++i)


### PR DESCRIPTION
* remove inferstatically from initialize

* increase timeout

* use mutable item for consistency

* remove hardcoded call to TF_InferStatically

* keep const ref to item