### PR TITLE
Add `tensorflow` and `tensorflow-cpu` testing to the CI matrix

### DIFF
--- a/pipelines/create_report_email.ps1
+++ b/pipelines/create_report_email.ps1
@@ -354,7 +354,7 @@ if ($TestsArtifactsExist)
                 $Html += "<td rowspan=`"$TestGroupArtifactCount`" colspan=`"1`" style=`"$CellStyle`">$TestGroup</td>"
             }
 
-            $CellStyle = "border:1px solid gray; background-color: ${AgentColors[$AgentJob.agent]}"
+            $CellStyle = "border:1px solid gray; background-color: $($AgentColors[$AgentJob.agent])"
             if ($FirstAgentRow)
             {
                 $FirstAgentRow = $False

--- a/pipelines/create_report_email.ps1
+++ b/pipelines/create_report_email.ps1
@@ -305,9 +305,22 @@ if ($TestsArtifactsExist)
         elseif ($TestGroupSummary.tests_passed_count -gt 0) { $GroupColor = $Green }
         else                                                { $GroupColor = $Gray }
 
-        $AgentJobs = $TestGroupSummary | Sort-Object -Property agent
+        $AgentJobs = $TestGroupSummary | Sort-Object -Property agent,build
         $CurrentAgentName = $null
-        $AgentColor = $Gray
+
+        $AgentColors = @{}
+
+        # Determine agent cell color.
+        foreach ($AgentJob in $AgentJobs)
+        {
+            if (-not $AgentColors.ContainsKey($AgentJob.agent))
+            {
+                $AgentColors[$AgentJob.agent] = $Gray
+            }
+
+            if     ($AgentJob.tests_failed_count -gt 0) { $AgentColors[$AgentJob.agent] = $Red }
+            elseif ($AgentJob.tests_passed_count -gt 0 -and $AgentColors[$AgentJob.agent] -ne $Red) { $AgentColors[$AgentJob.agent] = $Green }
+        }
 
         foreach ($AgentJob in $AgentJobs)
         {
@@ -317,10 +330,6 @@ if ($TestsArtifactsExist)
             $AgentArtifactsCount = ($AgentJobs | ? agent -eq $AgentName).count
 
             $AgentInfo = $AgentSummary.$AgentName
-
-            # Determine agent cell color.
-            if     ($AgentJob.tests_failed_count -gt 0) { $AgentColor = $Red }
-            elseif ($AgentJob.tests_passed_count -gt 0 -and $AgentColor -ne $Red) { $AgentColor = $Green }
 
             if ($AgentJob.agentHasResults)
             {
@@ -345,7 +354,7 @@ if ($TestsArtifactsExist)
                 $Html += "<td rowspan=`"$TestGroupArtifactCount`" colspan=`"1`" style=`"$CellStyle`">$TestGroup</td>"
             }
 
-            $CellStyle = "border:1px solid gray; background-color: $AgentColor"
+            $CellStyle = "border:1px solid gray; background-color: ${AgentColors[$AgentJob.agent]}"
             if ($FirstAgentRow)
             {
                 $FirstAgentRow = $False

--- a/pipelines/create_report_email.ps1
+++ b/pipelines/create_report_email.ps1
@@ -307,6 +307,8 @@ if ($TestsArtifactsExist)
 
         $AgentJobs = $TestGroupSummary | Sort-Object -Property agent
         $CurrentAgentName = $null
+        $AgentColor = $Gray
+
         foreach ($AgentJob in $AgentJobs)
         {
             $AgentName = $AgentJob.agent
@@ -318,8 +320,7 @@ if ($TestsArtifactsExist)
 
             # Determine agent cell color.
             if     ($AgentJob.tests_failed_count -gt 0) { $AgentColor = $Red }
-            elseif ($AgentJob.tests_passed_count -gt 0) { $AgentColor = $Green }
-            else                                        { $AgentColor = $Gray }
+            elseif ($AgentJob.tests_passed_count -gt 0 -and $AgentColor -ne $Red) { $AgentColor = $Green }
 
             if ($AgentJob.agentHasResults)
             {

--- a/pipelines/create_test_matrix.ps1
+++ b/pipelines/create_test_matrix.ps1
@@ -27,6 +27,9 @@ Param
     # List of all possible build artifacts to test.
     [Parameter(Mandatory)][string[]]$Artifacts,
 
+    # List of all possible tensorflow packages to test against.
+    [Parameter(Mandatory)][string[]]$TensorflowPackages,
+
     # List of all possible test groups to test.
     [Parameter(Mandatory)][string[]]$TestGroups,
 
@@ -61,10 +64,13 @@ foreach ($AgentPoolName in $AgentPoolNames)
             # Agents may support a subset of test groups, which is stored as a regex in the 'AP.SupportedTestGroups'
             # agent capability. If not set, this will match all test groups.
             $SupportedTestGroups = $TestGroups -match $Agent.UserCapabilities.'AP.TfTestGroups'
-    
-            foreach ($TestGroup in $SupportedTestGroups)
+
+            foreach ($TensorflowPackage in $TensorflowPackages)
             {
-                $TestConfigurations.Add("${Artifact}:${TestGroup}") | Out-Null
+                foreach ($TestGroup in $SupportedTestGroups)
+                {
+                    $TestConfigurations.Add("${Artifact}:${TensorflowPackage}:${TestGroup}") | Out-Null
+                }
             }
         }
     

--- a/pipelines/create_test_summary_json.ps1
+++ b/pipelines/create_test_summary_json.ps1
@@ -35,7 +35,7 @@ foreach ($Job in $TestMatrix)
 
         $SummaryEntry = @{
             "agent" = $Job.agentName;
-            "build" = $Build;
+            "build" = ${Build}-${TensorflowPackage};
             "agentWasOnline" = $Job.agentStatus -eq 'online';
             "agentWasEnabled" = $Job.agentEnabled;
             "agentHasResults" = Test-Path $ResultsPath;

--- a/pipelines/create_test_summary_json.ps1
+++ b/pipelines/create_test_summary_json.ps1
@@ -35,7 +35,7 @@ foreach ($Job in $TestMatrix)
 
         $SummaryEntry = @{
             "agent" = $Job.agentName;
-            "build" = ${Build}-${TensorflowPackage};
+            "build" = "${Build}-${TensorflowPackage}";
             "agentWasOnline" = $Job.agentStatus -eq 'online';
             "agentWasEnabled" = $Job.agentEnabled;
             "agentHasResults" = Test-Path $ResultsPath;

--- a/pipelines/create_test_summary_json.ps1
+++ b/pipelines/create_test_summary_json.ps1
@@ -25,8 +25,8 @@ foreach ($Job in $TestMatrix)
 {
     foreach ($TestConfig in $Job.agentTestConfigs)
     {
-        $Build, $Group = $TestConfig.split(':')
-        $ResultsPath = "$TestArtifactsPath/$($Job.agentName)/$Build/summary.$Group.json"
+        $Build, $TensorflowPackage, $Group = $TestConfig.split(':')
+        $ResultsPath = "$TestArtifactsPath/$($Job.agentName)/$Build/$TensorflowPackage/summary.$Group.json"
 
         if (!$Summary.ContainsKey($Group))
         {

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -52,10 +52,15 @@ parameters:
   type: object
   default: [ops, plugin]
 
-- name: testTensorflowPackage
+- name: testTensorflowPackages
+  displayName: TensorFlow Packages To Test Against
+  type: object
+  default: [tensorflow, tensorflow-cpu]
+
+- name: testTensorflowVersion
   displayName: TensorFlow Package Version
   type: string
-  default: tensorflow-cpu==2.9.1
+  default: 2.9.1
 
 - name: testKerasPackage
   displayName: TensorFlow Package Version
@@ -121,7 +126,8 @@ stages:
       parameters:
         testGroups: ${{parameters.testGroups}}
         artifacts: ${{parameters.testArtifacts}}
-        tensorflowPackage: ${{parameters.testTensorflowPackage}}
+        tensorflowPackages: ${{parameters.testTensorflowPackages}}
+        tensorflowVersion: ${{parameters.testTensorflowVersion}}
         kerasPackage: ${{parameters.testKerasPackage}}
 
 - stage: reportStage

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -128,7 +128,7 @@ jobs:
     - ${{each tensorflowPackage in parameters.tensorflowPackages}}:
       - ${{if contains(artifact, '-linux-') }}:
         - task: PowerShell@2
-          displayName: Setup ${{artifact}}
+          displayName: Setup ${{artifact}} (${{tensorflowPackage}})
           name: test_env_linux_${{replace(tensorflowPackage, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
@@ -141,7 +141,7 @@ jobs:
               wsl bash $ScriptPathWsl $TestArtifactPathWsl ${{tensorflowPackage}}==${{parameters.tensorflowVersion}} ${{parameters.kerasPackage}}
 
         - task: PowerShell@2
-          displayName: Test ${{artifact}}
+          displayName: Test ${{artifact}} (${{tensorflowPackage}})
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline
@@ -160,7 +160,7 @@ jobs:
 
       - ${{if contains(artifact, '-win-') }}:
         - task: PowerShell@2
-          displayName: Setup ${{artifact}}
+          displayName: Setup ${{artifact}} (${{tensorflowPackage}})
           name: test_env_win_${{replace(tensorflowPackage, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
@@ -172,7 +172,7 @@ jobs:
               -KerasPackage ${{parameters.kerasPackage}}
 
         - task: PowerShell@2
-          displayName: Test ${{artifact}}
+          displayName: Test ${{artifact}} (${{tensorflowPackage}})
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -150,8 +150,8 @@ jobs:
               $ScriptPathWsl = wsl wslpath -a $ScriptPath
 
               # Results are written to Linux filesystem ($ResultsDirLinux) and copied to Windows ($ResultsDirWin)
-              $ResultsDirLinux = "/tmp/tfdml_plugin_pipeline/results/$(agentName)/${{artifact}}"
-              $ResultsDirWin = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}" -replace '\\','/'
+              $ResultsDirLinux = "/tmp/tfdml_plugin_pipeline/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}"
+              $ResultsDirWin = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}" -replace '\\','/'
               $ResultsDirWinWsl = wsl wslpath -a $ResultsDirWin
               New-Item -ItemType Directory $ResultsDirWin -Force | Out-Null
 
@@ -178,7 +178,7 @@ jobs:
             targetType: inline
             script: |
               Invoke-Expression '$(test_env_win_${{replace(tensorflowPackage, '-', '_')}}.activateCommand)'
-              $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}"
+              $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}"
               python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 
     - task: PublishBuildArtifacts@1

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -14,9 +14,12 @@ parameters:
 - name: resultsArtifactName
   type: string
   default: test
-- name: tensorflowPackage
+- name: tensorflowPackages
+  type: object
+  default: [tensorflow, tensorflow-cpu]
+- name: tensorflowVersion
   type: string
-  default: tensorflow-cpu==2.9.1
+  default: 2.9.1
 - name: kerasPackage
   type: string
   default: keras==2.9.0
@@ -122,67 +125,68 @@ jobs:
       displayName: Download ${{artifact}}
       condition: contains(variables.agentTestConfigs, '${{artifact}}')
 
-    - ${{if contains(artifact, '-linux-') }}:
-      - task: PowerShell@2
-        displayName: Setup ${{artifact}}
-        name: test_env_linux
+    - ${{each tensorflowPackage in parameters.tensorflowPackages}}:
+      - ${{if contains(artifact, '-linux-') }}:
+        - task: PowerShell@2
+          displayName: Setup ${{artifact}}
+          name: test_env_linux
+          condition: contains(variables.agentTestConfigs, '${{artifact}}')
+          inputs:
+            targetType: inline
+            script: |
+              $ScriptPath = "$(Build.SourcesDirectory)/pipelines/create_test_env.sh" -replace '\\','/'
+              $ScriptPathWsl = wsl wslpath -a $ScriptPath
+              $TestArtifactPath = "$(buildArtifactsPathRoot)/${{artifact}}" -replace '\\','/'
+              $TestArtifactPathWsl = wsl wslpath -a $TestArtifactPath
+              wsl bash $ScriptPathWsl $TestArtifactPathWsl ${{tensorflowPackage}}==${{parameters.tensorflowVersion}} ${{parameters.kerasPackage}}
+
+        - task: PowerShell@2
+          displayName: Test ${{artifact}}
+          condition: contains(variables.agentTestConfigs, '${{artifact}}')
+          inputs:
+            targetType: inline
+            script: |
+              $ScriptPath = "$(Build.SourcesDirectory)/test/test.py" -replace '\\','/'
+              $ScriptPathWsl = wsl wslpath -a $ScriptPath
+
+              # Results are written to Linux filesystem ($ResultsDirLinux) and copied to Windows ($ResultsDirWin)
+              $ResultsDirLinux = "/tmp/tfdml_plugin_pipeline/results/$(agentName)/${{artifact}}"
+              $ResultsDirWin = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}" -replace '\\','/'
+              $ResultsDirWinWsl = wsl wslpath -a $ResultsDirWin
+              New-Item -ItemType Directory $ResultsDirWin -Force | Out-Null
+
+              cmd /c "wsl $(test_env_linux.activateCommand); python $ScriptPathWsl --run --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
+              wsl cp -r $ResultsDirLinux/* $ResultsDirWinWsl
+
+      - ${{if contains(artifact, '-win-') }}:
+        - task: PowerShell@2
+          displayName: Setup ${{artifact}}
+          name: test_env_win
+          condition: contains(variables.agentTestConfigs, '${{artifact}}')
+          inputs:
+            targetType: filePath
+            filePath: pipelines/create_test_env.ps1
+            arguments: >
+              -TestArtifactPath $(buildArtifactsPathRoot)/${{artifact}}
+              -TensorFlowPackage ${{tensorflowPackage}}==${{parameters.tensorflowVersion}}
+              -KerasPackage ${{parameters.kerasPackage}}
+
+        - task: PowerShell@2
+          displayName: Test ${{artifact}}
+          condition: contains(variables.agentTestConfigs, '${{artifact}}')
+          inputs:
+            targetType: inline
+            script: |
+              Invoke-Expression '$(test_env_win.activateCommand)'
+              $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}"
+              python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish ${{artifact}}
         condition: contains(variables.agentTestConfigs, '${{artifact}}')
         inputs:
-          targetType: inline
-          script: |
-            $ScriptPath = "$(Build.SourcesDirectory)/pipelines/create_test_env.sh" -replace '\\','/'
-            $ScriptPathWsl = wsl wslpath -a $ScriptPath
-            $TestArtifactPath = "$(buildArtifactsPathRoot)/${{artifact}}" -replace '\\','/'
-            $TestArtifactPathWsl = wsl wslpath -a $TestArtifactPath
-            wsl bash $ScriptPathWsl $TestArtifactPathWsl ${{parameters.tensorflowPackage}} ${{parameters.kerasPackage}}
-
-      - task: PowerShell@2
-        displayName: Test ${{artifact}}
-        condition: contains(variables.agentTestConfigs, '${{artifact}}')
-        inputs:
-          targetType: inline
-          script: |
-            $ScriptPath = "$(Build.SourcesDirectory)/test/test.py" -replace '\\','/'
-            $ScriptPathWsl = wsl wslpath -a $ScriptPath
-
-            # Results are written to Linux filesystem ($ResultsDirLinux) and copied to Windows ($ResultsDirWin)
-            $ResultsDirLinux = "/tmp/tfdml_plugin_pipeline/results/$(agentName)/${{artifact}}"
-            $ResultsDirWin = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}" -replace '\\','/'
-            $ResultsDirWinWsl = wsl wslpath -a $ResultsDirWin
-            New-Item -ItemType Directory $ResultsDirWin -Force | Out-Null
-
-            cmd /c "wsl $(test_env_linux.activateCommand); python $ScriptPathWsl --run --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
-            wsl cp -r $ResultsDirLinux/* $ResultsDirWinWsl
-
-    - ${{if contains(artifact, '-win-') }}:
-      - task: PowerShell@2
-        displayName: Setup ${{artifact}}
-        name: test_env_win
-        condition: contains(variables.agentTestConfigs, '${{artifact}}')
-        inputs:
-          targetType: filePath
-          filePath: pipelines/create_test_env.ps1
-          arguments: >
-            -TestArtifactPath $(buildArtifactsPathRoot)/${{artifact}}
-            -TensorFlowPackage ${{parameters.tensorflowPackage}}
-            -KerasPackage ${{parameters.kerasPackage}}
-
-      - task: PowerShell@2
-        displayName: Test ${{artifact}}
-        condition: contains(variables.agentTestConfigs, '${{artifact}}')
-        inputs:
-          targetType: inline
-          script: |
-            Invoke-Expression '$(test_env_win.activateCommand)'
-            $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}"
-            python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish ${{artifact}}
-      condition: contains(variables.agentTestConfigs, '${{artifact}}')
-      inputs:
-        pathToPublish: $(System.ArtifactsDirectory)/results
-        artifactName: ${{parameters.resultsArtifactName}}
+          pathToPublish: $(System.ArtifactsDirectory)/results
+          artifactName: ${{parameters.resultsArtifactName}}
 
 #-------------------------------------------------------------------------------------------------------------------
 # Summarize Results

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -182,12 +182,12 @@ jobs:
               $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}"
               python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 
-      - task: PublishBuildArtifacts@1
-        displayName: Publish ${{artifact}} (${{tensorflowPackage}})
-        condition: contains(variables.agentTestConfigs, '${{artifact}}')
-        inputs:
-          pathToPublish: $(System.ArtifactsDirectory)/results
-          artifactName: ${{parameters.resultsArtifactName}}
+    - task: PublishBuildArtifacts@1
+      displayName: Publish ${{artifact}}
+      condition: contains(variables.agentTestConfigs, '${{artifact}}')
+      inputs:
+        pathToPublish: $(System.ArtifactsDirectory)/results
+        artifactName: ${{parameters.resultsArtifactName}}
 
 #-------------------------------------------------------------------------------------------------------------------
 # Summarize Results

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -43,6 +43,7 @@ jobs:
         -AccessToken "$(accessToken)"
         -AgentPoolNames ${{join(', ', parameters.agentPool)}}
         -Artifacts ${{join(', ', parameters.artifacts)}}
+        -TensorflowPackages ${{join(', ', parameters.tensorflowPackages)}}
         -TestGroups ${{join(', ', parameters.testGroups)}}
         -OutputFilePath "$(System.ArtifactsDirectory)/matrix.json"
         -OutputVariableName "testMatrix"

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -155,7 +155,7 @@ jobs:
               $ResultsDirWinWsl = wsl wslpath -a $ResultsDirWin
               New-Item -ItemType Directory $ResultsDirWin -Force | Out-Null
 
-              cmd /c "wsl $(test_env_linux.activateCommand); python $ScriptPathWsl --run --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
+              cmd /c "wsl $(test_env_linux_${{replace(tensorflowPackage, '-', '_')}}.activateCommand); python $ScriptPathWsl --run --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
               wsl cp -r $ResultsDirLinux/* $ResultsDirWinWsl
 
       - ${{if contains(artifact, '-win-') }}:
@@ -177,7 +177,7 @@ jobs:
           inputs:
             targetType: inline
             script: |
-              Invoke-Expression '$(test_env_win.activateCommand)'
+              Invoke-Expression '$(test_env_win_${{replace(tensorflowPackage, '-', '_')}}.activateCommand)'
               $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}"
               python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -129,7 +129,7 @@ jobs:
       - ${{if contains(artifact, '-linux-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_linux_${{replace(${{tensorflowPackage}}, '-', '_')}}
+          name: test_env_linux_${{replace(tensorflowPackage, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline
@@ -161,7 +161,7 @@ jobs:
       - ${{if contains(artifact, '-win-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_win_${{replace(${{tensorflowPackage}}, '-', '_')}}
+          name: test_env_win_${{replace(tensorflowPackage, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: filePath

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -181,12 +181,12 @@ jobs:
               $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}"
               python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 
-      - task: PublishBuildArtifacts@1
-        displayName: Publish ${{artifact}}
-        condition: contains(variables.agentTestConfigs, '${{artifact}}')
-        inputs:
-          pathToPublish: $(System.ArtifactsDirectory)/results
-          artifactName: ${{parameters.resultsArtifactName}}
+    - task: PublishBuildArtifacts@1
+      displayName: Publish ${{artifact}}
+      condition: contains(variables.agentTestConfigs, '${{artifact}}')
+      inputs:
+        pathToPublish: $(System.ArtifactsDirectory)/results
+        artifactName: ${{parameters.resultsArtifactName}}
 
 #-------------------------------------------------------------------------------------------------------------------
 # Summarize Results

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -68,7 +68,7 @@ jobs:
     name: $(agentPool)
     demands:
     - agent.name -equals $(agentName)
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   cancelTimeoutInMinutes: 1
   continueOnError: true
   variables:

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -182,12 +182,12 @@ jobs:
               $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}"
               python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish ${{artifact}}
-      condition: contains(variables.agentTestConfigs, '${{artifact}}')
-      inputs:
-        pathToPublish: $(System.ArtifactsDirectory)/results
-        artifactName: ${{parameters.resultsArtifactName}}
+      - task: PublishBuildArtifacts@1
+        displayName: Publish ${{artifact}} (${{tensorflowPackage}})
+        condition: contains(variables.agentTestConfigs, '${{artifact}}')
+        inputs:
+          pathToPublish: $(System.ArtifactsDirectory)/results
+          artifactName: ${{parameters.resultsArtifactName}}
 
 #-------------------------------------------------------------------------------------------------------------------
 # Summarize Results

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -129,7 +129,7 @@ jobs:
       - ${{if contains(artifact, '-linux-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_linux_$[replace(${{tensorflowPackage}}, '-', '_')]
+          name: test_env_linux_${{replace(${{tensorflowPackage}}, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline
@@ -161,7 +161,7 @@ jobs:
       - ${{if contains(artifact, '-win-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_win_$[replace(${{tensorflowPackage}}, '-', '_')]
+          name: test_env_win_${{replace(${{tensorflowPackage}}, '-', '_')}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: filePath

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -129,7 +129,7 @@ jobs:
       - ${{if contains(artifact, '-linux-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_linux
+          name: test_env_linux_${{tensorflowPackage}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline
@@ -161,7 +161,7 @@ jobs:
       - ${{if contains(artifact, '-win-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_win
+          name: test_env_win_${{tensorflowPackage}}
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: filePath

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -129,7 +129,7 @@ jobs:
       - ${{if contains(artifact, '-linux-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_linux_${{tensorflowPackage}}
+          name: test_env_linux_$[replace(${{tensorflowPackage}}, '-', '_')]
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: inline
@@ -161,7 +161,7 @@ jobs:
       - ${{if contains(artifact, '-win-') }}:
         - task: PowerShell@2
           displayName: Setup ${{artifact}}
-          name: test_env_win_${{tensorflowPackage}}
+          name: test_env_win_$[replace(${{tensorflowPackage}}, '-', '_')]
           condition: contains(variables.agentTestConfigs, '${{artifact}}')
           inputs:
             targetType: filePath


### PR DESCRIPTION
By testing against both `tensorflow` and `tensorflow-cpu`, we can hopefully catch more errors like the duplicate kernel issue that we became aware of recently.