### PR TITLE
Prevent unbounded growth of command allocator memory

### DIFF
--- a/tfdml/core/dml_command_allocator_ring.h
+++ b/tfdml/core/dml_command_allocator_ring.h
@@ -30,41 +30,44 @@ class DmlCommandAllocatorRing
   public:
     DmlCommandAllocatorRing(
         ID3D12Device* device,
-        D3D12_COMMAND_LIST_TYPE command_list_type)
+        D3D12_COMMAND_LIST_TYPE command_list_type,
+        DmlGpuEvent initial_event)
     {
         for (auto& info : command_allocators_)
         {
             DML_CHECK_SUCCEEDED(device->CreateCommandAllocator(
                 command_list_type,
                 IID_PPV_ARGS(&info.allocator)));
+
+            info.completion_event = initial_event;
         }
     }
 
-    ID3D12CommandAllocator* GetCurrentAllocator()
+    ID3D12CommandAllocator* GetNextAllocator(DmlGpuEvent next_completion_event)
     {
-        CommandAllocatorInfo& allocator_info =
-            command_allocators_[current_command_allocator_];
+        size_t earliest_other_allocator =
+            (current_command_allocator_ + 1) % allocator_count;
 
-        // Take the opportunity to reset the command allocator if possible.
-        if (allocator_info.completion_event.fence &&
-            allocator_info.completion_event.IsSignaled())
+        assert(
+            !command_allocators_[current_command_allocator_]
+                 .completion_event.IsSignaled() ||
+            command_allocators_[earliest_other_allocator]
+                .completion_event.IsSignaled());
+
+        if (command_allocators_[earliest_other_allocator]
+                .completion_event.IsSignaled())
         {
-            DML_CHECK_SUCCEEDED(allocator_info.Get()->Reset());
+            DML_CHECK_SUCCEEDED(
+                command_allocators_[earliest_other_allocator].Get()->Reset());
+            current_command_allocator_ = earliest_other_allocator;
         }
 
-        return command_allocators_[current_command_allocator_].Get();
-    }
-
-    void AdvanceAllocator(DmlGpuEvent completion_event)
-    {
         // Set the completion event for the current allocator so it can be reset
         // eventually.
         command_allocators_[current_command_allocator_].completion_event =
-            completion_event;
+            next_completion_event;
 
-        // Advance to the next allocator.
-        current_command_allocator_ =
-            (current_command_allocator_ + 1) % allocator_count;
+        return command_allocators_[current_command_allocator_].Get();
     }
 
   private:

--- a/tfdml/core/dml_command_allocator_ring.h
+++ b/tfdml/core/dml_command_allocator_ring.h
@@ -39,7 +39,7 @@ class DmlCommandAllocatorRing
                 command_list_type,
                 IID_PPV_ARGS(&info.allocator)));
 
-            info.completion_event = initial_event;
+            info.completion_event = std::move(initial_event);
         }
     }
 
@@ -65,7 +65,7 @@ class DmlCommandAllocatorRing
         // Set the completion event for the current allocator so it can be reset
         // eventually.
         command_allocators_[current_command_allocator_].completion_event =
-            next_completion_event;
+            std::move(next_completion_event);
 
         return command_allocators_[current_command_allocator_].Get();
     }

--- a/tfdml/core/dml_command_list.cc
+++ b/tfdml/core/dml_command_list.cc
@@ -25,12 +25,15 @@ namespace tfdml
 DmlCommandList::DmlCommandList(
     ID3D12Device* d3d_device,
     IDMLDevice* dml_device,
-    D3D12_COMMAND_LIST_TYPE command_list_type)
+    std::shared_ptr<DmlCommandQueue> queue)
     : d3d_device_(d3d_device),
       dml_device_(dml_device),
-      command_list_type_(command_list_type),
+      queue_(std::move(queue)),
       descriptor_pool_(d3d_device, 2048),
-      command_allocator_ring_(d3d_device, command_list_type)
+      command_allocator_ring_(
+          d3d_device,
+          queue_->GetType(),
+          queue_->GetCurrentCompletionEvent())
 {
     DML_CHECK_SUCCEEDED(
         dml_device->CreateCommandRecorder(IID_PPV_ARGS(&recorder_)));
@@ -253,20 +256,20 @@ void DmlCommandList::SetDescriptorHeap(ID3D12DescriptorHeap* descriptor_heap)
     }
 }
 
-void DmlCommandList::Open(DmlGpuEvent completion_event)
+void DmlCommandList::Open()
 {
     assert(current_descriptor_heap_ == nullptr);
-    current_completion_event_ = completion_event;
 
     ID3D12CommandAllocator* allocator =
-        command_allocator_ring_.GetCurrentAllocator();
+        command_allocator_ring_.GetNextAllocator(
+            queue_->GetNextCompletionEvent());
 
     if (!d3d_command_list_)
     {
         // Lazily create underlying D3D command list.
         DML_CHECK_SUCCEEDED(d3d_device_->CreateCommandList(
             0,
-            command_list_type_,
+            queue_->GetType(),
             allocator,
             nullptr,
             IID_PPV_ARGS(&d3d_command_list_)));
@@ -275,10 +278,6 @@ void DmlCommandList::Open(DmlGpuEvent completion_event)
     {
         DML_CHECK_SUCCEEDED(d3d_command_list_->Reset(allocator, nullptr));
     }
-
-    // The current command allocator will become eligible for reset once this
-    // command list completes execution
-    command_allocator_ring_.AdvanceAllocator(completion_event);
 }
 
 Status DmlCommandList::Close()

--- a/tfdml/core/dml_command_list.h
+++ b/tfdml/core/dml_command_list.h
@@ -34,7 +34,7 @@ class DmlCommandList
     DmlCommandList(
         ID3D12Device* d3d12_device,
         IDMLDevice* dml_device,
-        D3D12_COMMAND_LIST_TYPE command_list_type);
+        std::shared_ptr<DmlCommandQueue> queue);
 
     // Records a CopyBufferRegion (see
     // ID3D12GraphicsCommandList::CopyBufferRegion) for execution. Transition
@@ -78,10 +78,8 @@ class DmlCommandList
     void UavBarrier();
 
     // Opens the command list for recording, which is required before any of the
-    // above methods can be called. The supplied completion event indicates the
-    // fence value that will be signaled when the commands recorded to this
-    // command list have finished executing on the hardware.
-    void Open(DmlGpuEvent completion_event);
+    // above methods can be called.
+    void Open();
 
     // Closes the command list for recording, which is required before the
     // command list can be executed on a command queue. If any errors occur
@@ -96,8 +94,7 @@ class DmlCommandList
     Microsoft::WRL::ComPtr<IDMLDevice> dml_device_;
     Microsoft::WRL::ComPtr<IDMLCommandRecorder> recorder_;
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> d3d_command_list_;
-
-    D3D12_COMMAND_LIST_TYPE command_list_type_;
+    std::shared_ptr<DmlCommandQueue> queue_;
 
     // Descriptors are allocated from a pool. The current heap pointer is only
     // used to avoid redundantly setting the same heap; it does not have

--- a/tfdml/core/dml_execution_context.cc
+++ b/tfdml/core/dml_execution_context.cc
@@ -87,7 +87,7 @@ DmlExecutionContext::DmlExecutionContext(
     dml_command_list_ = std::make_shared<DmlCommandList>(
         d3d_device,
         dml_device,
-        dml_command_queue_->GetType());
+        dml_command_queue_);
 
     execution_thread_ = std::thread(
         ExecutionThreadProc,
@@ -339,7 +339,6 @@ D3D12_COMMAND_LIST_TYPE DmlExecutionContext::GetCommandListTypeForQueue() const
         // flush. The goal here is to balance feeding the GPU work while the CPU
         // is processing more commands and avoiding many small packets.
         bool flush = false;
-        DmlGpuEvent batch_completion_event = state->next_flush_event;
         if (state->flush_requested || batch.size() >= batch_flush_size ||
             elapsed_us >= batch_flush_time_us)
         {
@@ -356,7 +355,7 @@ D3D12_COMMAND_LIST_TYPE DmlExecutionContext::GetCommandListTypeForQueue() const
         {
             DmlTracing::Instance().LogExecutionContextFlush();
             // Record the commands into the command list.
-            command_list->Open(batch_completion_event);
+            command_list->Open();
             for (auto& command : batch)
             {
                 command(*command_list);

--- a/tfdml/optimizer/remapper.cc
+++ b/tfdml/optimizer/remapper.cc
@@ -490,8 +490,7 @@ Status Remapper::Optimize(
     tensorflow::GraphDef* optimized_graph)
 {
     RemapperContext ctx;
-    TF_RETURN_IF_ERROR(
-        RemapperContext::InitializeRemapperContext(item, &ctx));
+    TF_RETURN_IF_ERROR(RemapperContext::InitializeRemapperContext(item, &ctx));
     // Processing graph in reverse-topological sorted order allows to remap
     // longer chains of dependent ops in one pass.
     TF_RETURN_IF_ERROR(


### PR DESCRIPTION
This addresses a memory leak with the DML execution provider due to D3D12 command allocators not being reset in certain models and timing conditions.

The fix is to avoid advancing the command allocator within a ring buffer until the executions associated with the next allocator have completed and that allocator may therefore be reset.