### PR TITLE
Add parallel testing for nightly builds

### DIFF
--- a/pipelines/create_test_matrix.ps1
+++ b/pipelines/create_test_matrix.ps1
@@ -52,6 +52,11 @@ foreach ($AgentPoolName in $AgentPoolNames)
 
     foreach ($Agent in $Agents)
     {
+        if (-not $Agent.UserCapabilities.'AP.TfArtifacts')
+        {
+            continue
+        }
+
         # Flat list of "<artifact>:<testGroup>" configurations to test.
         $TestConfigurations = [System.Collections.ArrayList]::new()
     

--- a/pipelines/create_test_matrix.ps1
+++ b/pipelines/create_test_matrix.ps1
@@ -52,11 +52,6 @@ foreach ($AgentPoolName in $AgentPoolNames)
 
     foreach ($Agent in $Agents)
     {
-        if (-not $Agent.UserCapabilities.'AP.TfArtifacts')
-        {
-            continue
-        }
-
         # Flat list of "<artifact>:<testGroup>" configurations to test.
         $TestConfigurations = [System.Collections.ArrayList]::new()
     

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -79,6 +79,7 @@ jobs:
   workspace:
     clean: all
   steps:
+  - checkout: none
   - task: PowerShell@2
     name: vars
     displayName: Initialize Variables

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -156,7 +156,7 @@ jobs:
               $ResultsDirWinWsl = wsl wslpath -a $ResultsDirWin
               New-Item -ItemType Directory $ResultsDirWin -Force | Out-Null
 
-              cmd /c "wsl $(test_env_linux_${{replace(tensorflowPackage, '-', '_')}}.activateCommand); python $ScriptPathWsl --run --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
+              cmd /c "wsl $(test_env_linux_${{replace(tensorflowPackage, '-', '_')}}.activateCommand); python $ScriptPathWsl --run --parallel --summarize --redirect_output --results_dir $ResultsDirLinux --groups ${{join(' ', parameters.testGroups)}}"
               wsl cp -r $ResultsDirLinux/* $ResultsDirWinWsl
 
       - ${{if contains(artifact, '-win-') }}:
@@ -180,7 +180,7 @@ jobs:
             script: |
               Invoke-Expression '$(test_env_win_${{replace(tensorflowPackage, '-', '_')}}.activateCommand)'
               $ResultsDir = "$(System.ArtifactsDirectory)/results/$(agentName)/${{artifact}}/${{tensorflowPackage}}"
-              python $(Build.SourcesDirectory)/test/test.py --run --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
+              python $(Build.SourcesDirectory)/test/test.py --run --parallel --summarize --redirect_output --results_dir $ResultsDir --groups ${{join(' ', parameters.testGroups)}}
 
     - task: PublishBuildArtifacts@1
       displayName: Publish ${{artifact}}

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -79,7 +79,6 @@ jobs:
   workspace:
     clean: all
   steps:
-  - checkout: none
   - task: PowerShell@2
     name: vars
     displayName: Initialize Variables

--- a/test/test.py
+++ b/test/test.py
@@ -66,7 +66,7 @@ class TestGroup:
             results = []
 
             if self.parallel:
-                with Pool(processes=4) as pool:
+                with Pool(processes=6) as pool:
                     for test in self.tests:
                         result = pool.apply_async(_test_runner, (test, self.timeout_seconds, start_time))
                         results.append(result)


### PR DESCRIPTION
Nightly builds are starting to become pretty big, and since the bottleneck is the CPU as opposed to the GPU, we can leverage multiple cores instead of doing everything sequentially. This change distributes the test between 6 processes in a multiprocessing pool in order to keep the CPU and the GPU as busy as possible.