### PR TITLE
Upgrade DirectML to 1.9.0

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -46,8 +46,8 @@ FetchContent_Declare(
 # DirectML Redistributable NuGet package
 FetchContent_Declare(
     directml_redist
-    URL https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.2
-    URL_HASH SHA256=a58141244b075cc3abfdc247310224b68b64ddd2aaac25ea04ed703deb5d4f9b
+    URL https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.9.0
+    URL_HASH SHA256=052224190fa5db862694c29799c8eb7945191f5d0046b736f9864bd98417da14
 )
 
 # DirectMLX helper library

--- a/test/ops/resource_variable_ops_test.py
+++ b/test/ops/resource_variable_ops_test.py
@@ -1388,10 +1388,6 @@ class ResourceVariableOpsTest(test.TestCase,
 
   @test_util.disable_xla("b/208334252")  # XLA doesn't have a deterministic impl
   def testScatterAddDeterministic(self):
-    # TODO #38100209: Enable when Scatter ops use less memory to add duplicated
-    # indices together
-    self.skipTest("DML uses too much memory for some scatter operations")
-
     with context.eager_mode(), test_util.deterministic_ops():
       # Normally a nondeterministic codepath occurs when the variable has at
       # least 1024 elements. Test that op determinism ensures the op is

--- a/test/ops/resource_variable_ops_test.py
+++ b/test/ops/resource_variable_ops_test.py
@@ -1388,6 +1388,10 @@ class ResourceVariableOpsTest(test.TestCase,
 
   @test_util.disable_xla("b/208334252")  # XLA doesn't have a deterministic impl
   def testScatterAddDeterministic(self):
+    # TODO #38100209: Enable when Scatter ops use less memory to add duplicated
+    # indices together
+    self.skipTest("DML uses too much memory for some scatter operations")
+
     with context.eager_mode(), test_util.deterministic_ops():
       # Normally a nondeterministic codepath occurs when the variable has at
       # least 1024 elements. Test that op determinism ensures the op is


### PR DESCRIPTION
Upgrade DirectML to 1.9.0 and re-enable a `ScatterAdd` test since DirectML doesn't have the arbitrary size limit for resources anymore.