### PR TITLE
Fix test result dashboard not showing the errors anymore

### DIFF
--- a/pipelines/create_test_summary_xml.ps1
+++ b/pipelines/create_test_summary_xml.ps1
@@ -55,7 +55,7 @@ foreach ($Group in $Groups)
 
         $TensorflowPackageName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Leaf
         $BuildName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf
-        $AgentName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent Split-Path -Leaf
+        $AgentName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf
 
         foreach ($Test in $AgentSummary.tests)
         {

--- a/pipelines/create_test_summary_xml.ps1
+++ b/pipelines/create_test_summary_xml.ps1
@@ -19,7 +19,7 @@ param
     [int]$MaxLogLinesReportedPerTestFailure = 50
 )
 
-$AllSummaryFiles = (Get-ChildItem "$TestArtifactsPath\*\*\summary.*.json")
+$AllSummaryFiles = (Get-ChildItem "$TestArtifactsPath\summary.*.json" -Recurse)
 $Groups = $AllSummaryFiles.Name -replace 'summary\.(\w+)\.json', '$1' | Select-Object -Unique
 
 $XmlMemoryStream = [System.IO.MemoryStream]::new()

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -68,7 +68,7 @@ jobs:
     name: $(agentPool)
     demands:
     - agent.name -equals $(agentName)
-  timeoutInMinutes: 240
+  timeoutInMinutes: 90
   cancelTimeoutInMinutes: 1
   continueOnError: true
   variables:

--- a/test/tests.json
+++ b/test/tests.json
@@ -3,7 +3,7 @@
     "groups": [
         {
             "name": "ops",
-            "timeout_seconds": 7200,
+            "timeout_seconds": 5400,
             "tests": [
                 {
                     "file": "ops/aggregate_ops_test.py"


### PR DESCRIPTION
After adding the `tensorflow-cpu` and `tensorflow` packages to the test matrix, the test dashboard stopped showing test errors because the log files were now nested one level deeper. This change fixes the pipeline so that the test dashboard will look for the log files at the correct place.