### PR TITLE
Add RngSkip and RngReadAndSkip

### DIFF
--- a/pipelines/create_test_summary_xml.ps1
+++ b/pipelines/create_test_summary_xml.ps1
@@ -55,7 +55,7 @@ foreach ($Group in $Groups)
 
         $TensorflowPackageName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Leaf
         $BuildName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf
-        $AgentName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent Split-Path -Leaf
+        $AgentName = $AgentSummaryFile.FullName | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Leaf
 
         foreach ($Test in $AgentSummary.tests)
         {

--- a/pipelines/create_test_summary_xml.ps1
+++ b/pipelines/create_test_summary_xml.ps1
@@ -19,7 +19,7 @@ param
     [int]$MaxLogLinesReportedPerTestFailure = 50
 )
 
-$AllSummaryFiles = (Get-ChildItem "$TestArtifactsPath\*\*\summary.*.json")
+$AllSummaryFiles = (Get-ChildItem "$TestArtifactsPath\summary.*.json" -Recurse)
 $Groups = $AllSummaryFiles.Name -replace 'summary\.(\w+)\.json', '$1' | Select-Object -Unique
 
 $XmlMemoryStream = [System.IO.MemoryStream]::new()

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -68,7 +68,7 @@ jobs:
     name: $(agentPool)
     demands:
     - agent.name -equals $(agentName)
-  timeoutInMinutes: 240
+  timeoutInMinutes: 90
   cancelTimeoutInMinutes: 1
   continueOnError: true
   variables:

--- a/test/tests.json
+++ b/test/tests.json
@@ -3,7 +3,7 @@
     "groups": [
         {
             "name": "ops",
-            "timeout_seconds": 7200,
+            "timeout_seconds": 5400,
             "tests": [
                 {
                     "file": "ops/aggregate_ops_test.py"

--- a/tfdml/runtime_adapter/rng_alg.h
+++ b/tfdml/runtime_adapter/rng_alg.h
@@ -1,0 +1,53 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+namespace tfdml
+{
+
+enum Algorithm
+{
+    // The Philox algorithm, as described in paper
+    // ['Parallel Random Numbers: As Easy as 1, 2, 3']
+    // (https://www.thesalmons.org/john/random123/papers/random123sc11.pdf)
+    RNG_ALG_PHILOX = 1,
+    // The ThreeFry algorithm, as described in paper
+    // ['Parallel Random Numbers: As Easy as 1, 2, 3']
+    // (https://www.thesalmons.org/john/random123/papers/random123sc11.pdf)
+    RNG_ALG_THREEFRY = 2,
+    // An algorithm auto-selected by the system according to device type.
+    RNG_ALG_AUTO_SELECT = 3
+};
+
+static constexpr int RNG_KEY_SIZE = 1;
+static constexpr int RNG_MAX_COUNTER_SIZE = 2;
+// Gets the counter size (in unit of uint64) for a counter-based RNG
+// algorithm `alg`. In the case of RNG_ALG_AUTO_SELECT, gets the minimal
+// counter size among all algorithms.
+inline int GetCounterSize(Algorithm alg)
+{
+    if (alg == RNG_ALG_PHILOX)
+    {
+        return 2;
+    }
+    else if (alg == RNG_ALG_THREEFRY)
+    {
+        return 1;
+    }
+    return 1;
+}
+
+} // end namespace tfdml


### PR DESCRIPTION
As https://github.com/microsoft/tensorflow-directml-plugin/issues/217 shows, `RngReadAndSkip` is used by `tf.keras.layers.experimental.preprocessing.Random*`. Implementing `RngSkip` and `RngReadAndSkip` allows users to use this experimental random operator at the python level.