### PR TITLE
Schedule nightly builds even when no changes were made

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -9,6 +9,16 @@ trigger: none
 # Do not trigger on PRs.
 pr: none
 
+# Build nightly at 5 AM UTC (10 PM PDT)
+schedules:
+- cron: "0 5 * * *"
+  displayName: Nightly Run
+  branches:
+    include:
+    - main
+    - release/*
+  always: false
+
 parameters:
 - name: releaseBuild
   displayName: Release Build


### PR DESCRIPTION
Like the `tensorflow-directml` build, having a nightly run scheduled regardless of whether changes were made during that day can help catch regressions due to driver updates, or catch sporadic failures. Also, some machines can be offline during a specific run and will need to be included in next day's run, even if no changes were made.