### PR TITLE
Fix undefined behavior in GetAttr<std::vector<std::string>>

### DIFF
--- a/tfdml/runtime_adapter/op_kernel_construction.h
+++ b/tfdml/runtime_adapter/op_kernel_construction.h
@@ -425,7 +425,7 @@ class OpKernelConstruction
 
         for (int32_t i = 0; i < list_size; ++i)
         {
-            (*value)[i] = vals[i];
+            (*value)[i] = std::string(vals[i], lengths[i]);
         }
 
         return status;


### PR DESCRIPTION
`OpKernelConstruction::GetAttr<std::vector<std::string>>` assumes that the strings are null terminated, which is not the case. Instead, we have to use the `lengths` value returned by `TF_OpKernelConstruction_GetAttrStringList` to figure out where the string ends.