### PR TITLE
Fix crash when using Neg with int64

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -54,7 +54,7 @@ FetchContent_Declare(
 # DirectMLX helper library
 FetchContent_Declare(
     directmlx
-    URL https://raw.githubusercontent.com/microsoft/DirectML/c14fc8bd5344eb34ce6b21f76a2b4ef28eb5ecc5/Libraries/DirectMLX.h
+    URL https://raw.githubusercontent.com/microsoft/DirectML/9d051781349b1c706695b148e2e31eb9c50de226/Libraries/DirectMLX.h
     URL_HASH SHA256=81bd6b556356b438e84ec681fe975e87d94b4363ee95caa2e2401a237fed0ee3
     DOWNLOAD_NO_EXTRACT TRUE
 )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -54,8 +54,8 @@ FetchContent_Declare(
 # DirectMLX helper library
 FetchContent_Declare(
     directmlx
-    URL https://raw.githubusercontent.com/microsoft/DirectML/bb6e396d87bd7976d2acda380ddd7cec45eb4589/Libraries/DirectMLX.h
-    URL_HASH SHA256=06e6738e987d426ced141f232d4ce348b791539f5865c88f4188061e2aeaf3bd
+    URL https://raw.githubusercontent.com/microsoft/DirectML/c14fc8bd5344eb34ce6b21f76a2b4ef28eb5ecc5/Libraries/DirectMLX.h
+    URL_HASH SHA256=81bd6b556356b438e84ec681fe975e87d94b4363ee95caa2e2401a237fed0ee3
     DOWNLOAD_NO_EXTRACT TRUE
 )
 

--- a/test/ops/relu_op_test.py
+++ b/test/ops/relu_op_test.py
@@ -611,7 +611,6 @@ class CreluTest(test.TestCase):
       self._testCrelu(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t))
 
-  #TODO: TFDML #40727997 Neg segfaults in WSL
   def testNumbersWithAxis0(self):
     tf_crelu = nn_ops.crelu(
         np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]), axis=0)
@@ -619,7 +618,6 @@ class CreluTest(test.TestCase):
                          [0, 3, 0, 7, 0]])
     self.assertAllEqual(np_crelu, tf_crelu)
 
-  #TODO: TFDML #40727997 Neg segfaults in WSL
   def testNumbersWithAxis1(self):
     tf_crelu = nn_ops.crelu(
         np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]), axis=1)


### PR DESCRIPTION
DirectML doesn't support `dml::Identity` with a scale, so I added the new `dml::Negate` operator to `DirectMLX` and use it as `operator-` when available.