### PR TITLE
Disable plugin_get_allocator_stats

### DIFF
--- a/tfdml/plugin/plugin_device.cc
+++ b/tfdml/plugin/plugin_device.cc
@@ -145,9 +145,9 @@ TF_Bool plugin_get_allocator_stats(
     const SP_Device* device,
     SP_AllocatorStats* stats)
 {
-    stats->struct_size = SP_ALLOCATORSTATS_STRUCT_SIZE;
-    stats->bytes_in_use = 123;
-    return true;
+    // TODO: Return allocator information
+    // #TFDML 40858257
+    return false;
 }
 
 TF_Bool plugin_device_memory_usage(

--- a/tfdml/plugin/plugin_device.cc
+++ b/tfdml/plugin/plugin_device.cc
@@ -146,7 +146,7 @@ TF_Bool plugin_get_allocator_stats(
     SP_AllocatorStats* stats)
 {
     // TODO: Return allocator information
-    // #TFDML 40858257
+    // TFDML 40858257
     return false;
 }
 


### PR DESCRIPTION
`plugin_get_allocator_stats` never returned anything useful, so it should return `false` for the moment so that TensorFlow knows not to rely on the information for now.