### PR TITLE
Disable the Summarize task on TF that don't support TF workflows

### DIFF
--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -197,7 +197,9 @@ jobs:
 - job: summarize
   displayName: Summarize Results
   dependsOn: test
-  pool: ${{parameters.agentPool}}
+  pool:
+    name: ${{parameters.agentPool}}
+    demands: AP.TfArtifacts
   timeoutInMinutes: 30
   condition: succeededOrFailed()
   continueOnError: true


### PR DESCRIPTION
We've been having issues with unstable machines internally that make the whole test pipeline fail at the end just because they cannot checkout a github repository, so we shouldn't ignore those machines when picking the next available one.