### PR TITLE
Add a nightly build via GitHub Actions

### DIFF
--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -9,15 +9,15 @@ jobs:
   build-manylinux:
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9, 3.10]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
         include:
-          - python_version: 3.7
+          - python_version: "3.7"
             cp_version: cp37
-          - python_version: 3.8
+          - python_version: "3.8"
             cp_version: cp38
-          - python_version: 3.9
+          - python_version: "3.9"
             cp_version: cp39
-          - python_version: 3.10
+          - python_version: "3.10"
             cp_version: cp310
     name: Build x64-linux-release-${{ matrix.cp_version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     # Build nightly at 5 AM UTC (10 PM PDT)
     - cron:  "0 5 * * *"
-  push:
-    branches: [user/pavignol/add-github-actions-nightly-build]
 jobs:
   build-manylinux:
     strategy:

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -1,0 +1,105 @@
+name: Nightly Build
+on:
+  schedule:
+    # Build nightly at 5 AM UTC (10 PM PDT)
+    - cron:  "0 5 * * *"
+  push:
+    branches: [user/pavignol/add-github-actions-nightly-build]
+jobs:
+  build-manylinux:
+    strategy:
+      matrix:
+        python_version: [3.7, 3.8, 3.9, 3.10]
+        include:
+          - python_version: 3.7
+            cp_version: cp37
+          - python_version: 3.8
+            cp_version: cp38
+          - python_version: 3.9
+            cp_version: cp39
+          - python_version: 3.10
+            cp_version: cp310
+    name: Build x64-linux-release-${{ matrix.cp_version }}
+    runs-on: ubuntu-latest
+    container:
+      image: tensorflow/tensorflow:2.5.0-custom-op-ubuntu16
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install CMake
+        run: |
+          wget --output-document="/tmp/cmake.sh" https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.sh
+          mkdir "/tmp/cmake"
+          bash "/tmp/cmake.sh" --skip-license --prefix="/tmp/cmake"
+          echo "/tmp/cmake/bin:${PATH}" >> $GITHUB_PATH
+      - name: Install Ninja
+        run: |
+          apt update
+          apt install ninja-build -y
+      - name: Install Miniconda
+        run: |
+          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --directory-prefix /tmp
+          bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /tmp/miniconda3
+          eval "$(/tmp/miniconda3/bin/conda shell.bash hook)"
+          conda create --name build python=${{ matrix.python_version }} -y
+          conda activate build
+          pip install wheel
+      - name: Build
+        run: |
+          export CXX=/usr/bin/clang++-8
+          eval "$(/tmp/miniconda3/bin/conda shell.bash hook)"
+          conda activate build
+          python build.py --config release
+      - uses: actions/upload-artifact@v3
+        with:
+          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-linux_x86_64.whl
+  build-windows-latest:
+    strategy:
+      matrix:
+        python_version: [3.7, 3.8, 3.9, 3.10]
+        include:
+          - python_version: 3.7
+            cp_version: cp37
+          - python_version: 3.8
+            cp_version: cp38
+          - python_version: 3.9
+            cp_version: cp39
+          - python_version: 3.10
+            cp_version: cp310
+    name: Build x64-win-release-${{ matrix.cp_version }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install CMake
+        shell: pwsh
+        run: |
+          $Url = 'https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-windows-x86_64.zip'
+          $DownloadPath = "$env:TEMP/cmake.zip"
+          (New-Object System.Net.WebClient).DownloadFile($Url, $DownloadPath)
+          Expand-Archive $DownloadPath -DestinationPath cmake
+          "$env:TEMP/cmake-3.22.1-windows-x86_64/bin" >> $env:GITHUB_PATH
+      - name: Download Miniconda
+        shell: pwsh
+        run: |
+          $Url = 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe'
+          $DownloadPath = "$env:TEMP/miniconda.exe"
+          (New-Object System.Net.WebClient).DownloadFile($Url, $DownloadPath)
+      - name: Install Miniconda
+        shell: cmd
+        run: |
+          %TEMP%\miniconda.exe /NoRegistry=1 /InstallationType=JustMe /RegisterPython=0 /S /D=%TEMP%\miniconda3
+      - name: Create Miniconda Environment
+        shell: pwsh
+        run: |
+          & "$env:TEMP/miniconda3/shell/condabin/conda-hook.ps1"
+          conda create --name build python=${{ matrix.python_version }} -y
+          conda activate build
+          pip install wheel vswhere
+      - name: Build
+        shell: pwsh
+        run: |
+          & "$env:TEMP/miniconda3/shell/condabin/conda-hook.ps1"
+          conda activate build
+          python build.py --config release
+      - uses: actions/upload-artifact@v3
+        with:
+          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-win_amd64.whl

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -55,15 +55,15 @@ jobs:
   build-windows-latest:
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9, 3.10]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
         include:
-          - python_version: 3.7
+          - python_version: "3.7"
             cp_version: cp37
-          - python_version: 3.8
+          - python_version: "3.8"
             cp_version: cp38
-          - python_version: 3.9
+          - python_version: "3.9"
             cp_version: cp39
-          - python_version: 3.10
+          - python_version: "3.10"
             cp_version: cp310
     name: Build x64-win-release-${{ matrix.cp_version }}
     runs-on: windows-latest

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -48,9 +48,10 @@ jobs:
           export CXX=/usr/bin/clang++-8
           eval "$(/tmp/miniconda3/bin/conda shell.bash hook)"
           conda activate build
-          python build.py --config release
+          python build.py --config=release --telemetry --telemetry_provider_group_guid="${{ secrets.TELEMETRY_PROVIDER_GROUP_GUID }}"
       - uses: actions/upload-artifact@v3
         with:
+          name: tensorflow-directml-plugin-linux-x86-x64-${{ github.sha }}
           path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-linux_x86_64.whl
   build-windows-latest:
     strategy:
@@ -99,7 +100,8 @@ jobs:
         run: |
           & "$env:TEMP/miniconda3/shell/condabin/conda-hook.ps1"
           conda activate build
-          python build.py --config release
+          python build.py --config=release --telemetry --telemetry_provider_group_guid="${{ secrets.TELEMETRY_PROVIDER_GROUP_GUID }}"
       - uses: actions/upload-artifact@v3
         with:
+          name: tensorflow-directml-plugin-win-amd64-${{ github.sha }}
           path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-win_amd64.whl

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -12,14 +12,18 @@ jobs:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - python_version: "3.7"
-            cp_version: cp37
+            cp_version_prefix: cp37
+            cp_version_suffix: cp37m
           - python_version: "3.8"
-            cp_version: cp38
+            cp_version_prefix: cp38
+            cp_version_suffix: cp38
           - python_version: "3.9"
-            cp_version: cp39
+            cp_version_prefix: cp39
+            cp_version_suffix: cp39
           - python_version: "3.10"
-            cp_version: cp310
-    name: Build x64-linux-release-${{ matrix.cp_version }}
+            cp_version_prefix: cp310
+            cp_version_suffix: cp310
+    name: Build x64-linux-release-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}
     runs-on: ubuntu-latest
     container:
       image: tensorflow/tensorflow:2.5.0-custom-op-ubuntu16
@@ -52,21 +56,25 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: tensorflow-directml-plugin-linux-x86-x64-${{ github.sha }}
-          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-linux_x86_64.whl
+          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-linux_x86_64.whl
   build-windows-latest:
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - python_version: "3.7"
-            cp_version: cp37
+            cp_version_prefix: cp37
+            cp_version_suffix: cp37m
           - python_version: "3.8"
-            cp_version: cp38
+            cp_version_prefix: cp38
+            cp_version_suffix: cp38
           - python_version: "3.9"
-            cp_version: cp39
+            cp_version_prefix: cp39
+            cp_version_suffix: cp39
           - python_version: "3.10"
-            cp_version: cp310
-    name: Build x64-win-release-${{ matrix.cp_version }}
+            cp_version_prefix: cp310
+            cp_version_suffix: cp310
+    name: Build x64-win-release-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -104,4 +112,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: tensorflow-directml-plugin-win-amd64-${{ github.sha }}
-          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version }}-${{ matrix.cp_version }}-win_amd64.whl
+          path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-win_amd64.whl

--- a/.github/workflows/github-actions-nightly-build.yml
+++ b/.github/workflows/github-actions-nightly-build.yml
@@ -55,7 +55,7 @@ jobs:
           python build.py --config=release --telemetry --telemetry_provider_group_guid="${{ secrets.TELEMETRY_PROVIDER_GROUP_GUID }}"
       - uses: actions/upload-artifact@v3
         with:
-          name: tensorflow-directml-plugin-linux-x86-x64-${{ github.sha }}
+          name: tensorflow_directml_plugin-${{ github.sha }}-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-linux_x86_64
           path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-linux_x86_64.whl
   build-windows-latest:
     strategy:
@@ -111,5 +111,5 @@ jobs:
           python build.py --config=release --telemetry --telemetry_provider_group_guid="${{ secrets.TELEMETRY_PROVIDER_GROUP_GUID }}"
       - uses: actions/upload-artifact@v3
         with:
-          name: tensorflow-directml-plugin-win-amd64-${{ github.sha }}
+          name: tensorflow_directml_plugin-${{ github.sha }}-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-win_amd64
           path: build/tensorflow_directml_plugin-*-${{ matrix.cp_version_prefix }}-${{ matrix.cp_version_suffix }}-win_amd64.whl

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TensorFlow-DirectML-Plugin <!-- omit in toc -->
 
 [![Build Status](https://microsoft.visualstudio.com/WindowsAI/_apis/build/status/TensorFlow/v2/TF2%20Plugin%20Build?branchName=main)](https://microsoft.visualstudio.com/WindowsAI/_build/latest?definitionId=76376&branchName=main)
+[![Nightly Build](https://github.com/microsoft/tensorflow-directml-plugin/actions/workflows/github-actions-nightly-build.yml/badge.svg?event=schedule)](https://github.com/microsoft/tensorflow-directml-plugin/actions/workflows/github-actions-nightly-build.yml)
 
 [TensorFlow](https://www.tensorflow.org/) is an end-to-end open source platform for machine learning. This repository is an implementation of [TensorFlow's Pluggable Device API](https://blog.tensorflow.org/2021/06/pluggabledevice-device-plugins-for-TensorFlow.html) that leverages [DirectML](https://github.com/microsoft/DirectML) to provide cross-vendor hardware acceleration on Windows 10 and the Windows Subsystem for Linux (WSL). TensorFlow with DirectML enables training and inference of complex machine learning models on a wide range of DirectX 12-compatible hardware.
 
@@ -72,7 +73,7 @@ The software may collect information about you and your use of the software and 
 
 ### Disabling Telemetry
 
-The official builds of tensorflow-directml-plugin (hosted on [PyPI](https://pypi.org/project/tensorflow-directml-plugin/)) have data collection enabled. This telemetry is enabled when building with `--config=dml_telemetry` (i.e. the `--telemetry` switch in `build.py`), but it is disabled by default for local builds.
+The official builds of tensorflow-directml-plugin (hosted on [PyPI](https://pypi.org/project/tensorflow-directml-plugin/)) and the nightly builds uploaded by GitHub Actions have data collection enabled. This telemetry is enabled when building with `--config=dml_telemetry` (i.e. the `--telemetry` switch in `build.py`), but it is disabled by default for local builds.
 
 ## Trademarks Notice
 


### PR DESCRIPTION
Public nightly builds will allow us to easily share development wheels with the community when working on issues with them and gather quick feedback between releases.