### PR TITLE
Remove int64 -> uint64 reinterpret in Reduce

### DIFF
--- a/tfdml/kernels/dml_reduce_ops.cc
+++ b/tfdml/kernels/dml_reduce_ops.cc
@@ -617,13 +617,6 @@ class DmlReduceKernel : public DmlKernel
             output_shape,
             output_shape);
 
-        // Coerce the output datatype to unsigned, for argmin/argmax
-        if (is_arg_function_ && DataTypeIsInteger(output.desc.GetTfDataType()))
-        {
-            output.desc.ForceUnsignedDataType();
-            zero_outputs_ = true;
-        }
-
         DmlKernelTensors tensors;
         tensors.inputs = {input};
         tensors.outputs = {output};


### PR DESCRIPTION
Now that int64 is completely supported, we don't need the int64 -> uint64 hack for ArgMin/ArgMax anymore.