### PR TITLE
Fix the adapter description on Linux

### DIFF
--- a/tfdml/core/dml_adapter_impl.cc
+++ b/tfdml/core/dml_adapter_impl.cc
@@ -305,11 +305,15 @@ void DmlAdapterImpl::Initialize(IDXCoreAdapter* adapter)
         DXCoreAdapterProperty::DriverDescription,
         &driver_description_size));
 
-    std::vector<char> driver_description(driver_description_size);
+    std::string driver_description(driver_description_size, '\0');
     DML_CHECK_SUCCEEDED(adapter->GetProperty(
         DXCoreAdapterProperty::DriverDescription,
         driver_description_size,
-        driver_description.data()));
+        &driver_description[0]));
+
+    // Remove the terminating null character that
+    // DXCoreAdapterProperty::DriverDescription returned
+    driver_description.pop_back();
 
     LARGE_INTEGER driver_version;
     DML_CHECK_SUCCEEDED(adapter->GetProperty(
@@ -339,7 +343,7 @@ void DmlAdapterImpl::Initialize(IDXCoreAdapter* adapter)
     driver_version_ = tfdml::DriverVersion(driver_version.QuadPart);
     vendor_id_ = static_cast<tfdml::VendorID>(hardware_id.vendorID);
     device_id_ = hardware_id.deviceID;
-    description_.assign(driver_description.begin(), driver_description.end());
+    description_ = std::move(driver_description);
     is_compute_only_ = !is_graphics_supported;
 }
 


### PR DESCRIPTION
`IDXCoreAdapter::GetPropertySize(DXCoreAdapterProperty::DriverDescription, &driver_description_size)` returns the size of the string including the null terminating character, but the string that we pass to `std::string` shouldn't contain a terminating character. Therefore, after retrieving the adapter description, we need to remove the last character.