### PR TITLE
Fix ArgMin and ArgMax crash when output type is int16 or uint16

### DIFF
--- a/tfdml/kernels/dml_reduce_ops.cc
+++ b/tfdml/kernels/dml_reduce_ops.cc
@@ -653,11 +653,41 @@ class DmlReduceKernel : public DmlKernel
         }
         else if (is_arg_function_)
         {
+            // ARGMAX and ARGMIN in DML don't support outputs with less than 32
+            // bit precision
+            const bool is_low_precision_output =
+                dml_output_data_type == DML_TENSOR_DATA_TYPE_INT16 ||
+                dml_output_data_type == DML_TENSOR_DATA_TYPE_INT8;
+
+            auto casted_dml_output_data_type = dml_output_data_type;
+
+            if (is_low_precision_output)
+            {
+                casted_dml_output_data_type = DML_TENSOR_DATA_TYPE_INT32;
+            }
+            else
+            {
+                const bool is_low_precision_unsigned_output =
+                    dml_output_data_type == DML_TENSOR_DATA_TYPE_UINT16 ||
+                    dml_output_data_type == DML_TENSOR_DATA_TYPE_UINT8;
+
+                if (is_low_precision_unsigned_output)
+                {
+                    casted_dml_output_data_type = DML_TENSOR_DATA_TYPE_UINT32;
+                }
+            }
+
             result = dml::Reduce(
                 result,
                 reduce_function,
                 reduce_axes,
-                dml_output_data_type);
+                casted_dml_output_data_type);
+
+            // Cast back to the original TensorFlow low precision type
+            if (dml_output_data_type != casted_dml_output_data_type)
+            {
+                result = dml::Cast(result, dml_output_data_type);
+            }
         }
         else
         {


### PR DESCRIPTION
TensorFlow supports int16 and uint16 as the output type of ArgMin and ArgMax, but DirectML only supports int32/int64/uint32/uint64. Therefore, we need to call DirectML with an int32 type and then cast back to int16 when the operation is done.