### PR TITLE
Fix FloorMod test that failed because of accuracy

### DIFF
--- a/test/ops/math_ops_test.py
+++ b/test/ops/math_ops_test.py
@@ -602,6 +602,11 @@ class DivAndModTest(test_util.TensorFlowTestCase):
     divs = np.arange(-3, 0, .25).reshape(1, 12)
     return nums, divs
 
+  def floatTestDataFloorMod(self):
+    nums = np.arange(-10, 5, .25).reshape(60, 1)
+    divs = np.arange(-3, 0, .25).reshape(1, 12)
+    return nums, divs
+
   def numpySafeFloorDivInt(self, x, y):
     z = x // y
     # Numpy produces 0 for INT_MIN/-1, but we expect an overflow to INT_MIN
@@ -637,7 +642,7 @@ class DivAndModTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(tf2_result, tf_result)
 
   def testFloorModFloat(self):
-    nums, divs = self.floatTestData()
+    nums, divs = self.floatTestDataFloorMod()
     for dtype in [np.float16, np.float32, np.float64]:
       x = nums.astype(dtype)
       y = divs.astype(dtype)


### PR DESCRIPTION
Division in HLSL is allowed to have an error of 1 ULP, so it's possible that a division that should return an exact result (e.g. 6.0 / 2.0 == 3.0) actually returns an approximation (e.g. 6.0 / 2.0 == 2.99999). In most scenarios this is perfectly fine, but when using floor, it makes a huge difference and the end result will be way off (floor(2.99999) != floor(3.0)). For this reason, we cannot accurately test cases where x / y results in an integer.