### PR TITLE
Allow nonlocal memory usage for all adapters

### DIFF
--- a/tfdml/core/dml_adapter.cc
+++ b/tfdml/core/dml_adapter.cc
@@ -52,6 +52,11 @@ uint64_t DmlAdapter::QueryAvailableLocalMemory() const
     return impl_->QueryAvailableLocalMemory();
 }
 
+uint64_t DmlAdapter::QueryAvailableNonLocalMemory() const
+{
+    return impl_->QueryAvailableNonLocalMemory();
+}
+
 bool DmlAdapter::IsUmaAdapter() const { return impl_->IsUmaAdapter(); }
 
 const char* GetVendorName(VendorID id)

--- a/tfdml/core/dml_adapter.h
+++ b/tfdml/core/dml_adapter.h
@@ -109,6 +109,7 @@ class DmlAdapter
     uint64_t GetTotalDedicatedMemory() const;
     uint64_t GetTotalSharedMemory() const;
     uint64_t QueryAvailableLocalMemory() const;
+    uint64_t QueryAvailableNonLocalMemory() const;
     bool IsUmaAdapter() const;
 
   private:

--- a/tfdml/core/dml_adapter_impl.cc
+++ b/tfdml/core/dml_adapter_impl.cc
@@ -206,6 +206,20 @@ uint64_t DmlAdapterImpl::QueryAvailableLocalMemory() const
     return info.Budget;
 }
 
+uint64_t DmlAdapterImpl::QueryAvailableNonLocalMemory() const
+{
+    ComPtr<IDXGIAdapter3> adapter3;
+    DML_CHECK_SUCCEEDED(adapter_.As(&adapter3));
+
+    DXGI_QUERY_VIDEO_MEMORY_INFO info = {};
+    DML_CHECK_SUCCEEDED(adapter3->QueryVideoMemoryInfo(
+        0,
+        DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL,
+        &info));
+
+    return info.Budget;
+}
+
 bool IsSoftwareAdapter(IDXGIAdapter1* adapter)
 {
     // The only way this can fail is if a nullptr is passed in, so
@@ -355,6 +369,24 @@ uint64_t DmlAdapterImpl::QueryAvailableLocalMemory() const
     DXCoreAdapterMemoryBudgetNodeSegmentGroup query = {};
     query.nodeIndex = 0;
     query.segmentGroup = DXCoreSegmentGroup::Local;
+
+    DXCoreAdapterMemoryBudget info = {};
+    DML_CHECK_SUCCEEDED(dxcore_adapter->QueryState(
+        DXCoreAdapterState::AdapterMemoryBudget,
+        &query,
+        &info));
+
+    return info.budget;
+}
+
+uint64_t DmlAdapterImpl::QueryAvailableNonLocalMemory() const
+{
+    ComPtr<IDXCoreAdapter> dxcore_adapter;
+    DML_CHECK_SUCCEEDED(adapter_.As(&dxcore_adapter));
+
+    DXCoreAdapterMemoryBudgetNodeSegmentGroup query = {};
+    query.nodeIndex = 0;
+    query.segmentGroup = DXCoreSegmentGroup::NonLocal;
 
     DXCoreAdapterMemoryBudget info = {};
     DML_CHECK_SUCCEEDED(dxcore_adapter->QueryState(

--- a/tfdml/core/dml_adapter_impl.h
+++ b/tfdml/core/dml_adapter_impl.h
@@ -47,9 +47,8 @@ class DmlAdapterImpl
     }
 
     uint64_t GetTotalSharedMemory() const { return shared_memory_in_bytes_; }
-
     uint64_t QueryAvailableLocalMemory() const;
-
+    uint64_t QueryAvailableNonLocalMemory() const;
     bool IsUmaAdapter() const;
 
   private:

--- a/tfdml/plugin/plugin_device.cc
+++ b/tfdml/plugin/plugin_device.cc
@@ -159,13 +159,15 @@ TF_Bool plugin_device_memory_usage(
     const DmlAdapter& adapter = device_cache.GetAdapter(device->ordinal);
 
     uint64_t total_gpu_memory = adapter.GetTotalDedicatedMemory();
+    total_gpu_memory += adapter.GetTotalSharedMemory();
 
     if (adapter.IsUmaAdapter())
     {
         total_gpu_memory += adapter.GetTotalSharedMemory();
     }
 
-    *free = adapter.QueryAvailableLocalMemory();
+    *free = adapter.QueryAvailableLocalMemory() +
+            adapter.QueryAvailableNonLocalMemory();
     *total = total_gpu_memory;
 
     return true;


### PR DESCRIPTION
Previously, we only allows nonlocal memory for UMA adapters. But since running some more complex models (e.g. transformers) now cause some problems on all adapters, we should allow nonlocal memory usage as a short-term fix. This is a short-term solution; the long-term solution is to improve memory usage, but it will most likely require a lot more work and a new version of DirectML.