### PR TITLE
Fix memory leak in SegmentReduction ops and improve performance

### DIFF
--- a/tfdml/core/dml_device.cc
+++ b/tfdml/core/dml_device.cc
@@ -87,6 +87,16 @@ Status DmlDevice::CopyDeviceTensorToCPU(
         cpu_tensor);
 }
 
+Status DmlDevice::CopyDeviceTensorsToCPU(
+    absl::Span<const Tensor> device_tensors,
+    absl::Span<Tensor> cpu_tensors)
+{
+    return device_context_->CopyDeviceTensorsToCPU(
+        this,
+        device_tensors,
+        cpu_tensors);
+}
+
 void DmlDevice::CopyTensorInSameDevice(
     const Tensor* input_tensor,
     Tensor* output_tensor)

--- a/tfdml/core/dml_device.h
+++ b/tfdml/core/dml_device.h
@@ -65,6 +65,10 @@ class DmlDevice : public Device
         const Tensor* device_tensor,
         Tensor* cpu_tensor) final;
 
+    Status CopyDeviceTensorsToCPU(
+        absl::Span<const Tensor> device_tensors,
+        absl::Span<Tensor> cpu_tensors) final;
+
   private:
     const DmlDeviceState* state_; // Weak; owned by the device factory
     std::unique_ptr<DMLDeviceContext> device_context_;

--- a/tfdml/core/dml_device_context.cc
+++ b/tfdml/core/dml_device_context.cc
@@ -123,7 +123,8 @@ Status DMLDeviceContext::CopyDeviceTensorsToCPU(
 
     DmlGpuEvent copy_event;
 
-    for (int i = 0; i < device_tensors.size(); ++i) {
+    for (int i = 0; i < device_tensors.size(); ++i)
+    {
         const Tensor& device_tensor = device_tensors[i];
         Tensor& cpu_tensor = cpu_tensors[i];
 
@@ -136,8 +137,8 @@ Status DMLDeviceContext::CopyDeviceTensorsToCPU(
         D3D12BufferRegion src = GetBufferForTensor(device_tensor);
         void* dst_data = cpu_tensor.base<void>();
 
-        // Performs a blocking call to synchronize and read back data from the GPU
-        // into the destination buffer
+        // Performs a blocking call to synchronize and read back data from the
+        // GPU into the destination buffer
         auto byte_span =
             absl::Span<uint8_t>(static_cast<uint8_t*>(dst_data), total_bytes);
 

--- a/tfdml/core/dml_device_context.cc
+++ b/tfdml/core/dml_device_context.cc
@@ -114,6 +114,49 @@ Status DMLDeviceContext::CopyDeviceTensorToCPU(
     return Status::OK();
 }
 
+Status DMLDeviceContext::CopyDeviceTensorsToCPU(
+    DmlDevice* device,
+    absl::Span<const Tensor> device_tensors,
+    absl::Span<Tensor> cpu_tensors)
+{
+    assert(device_tensors.size() == cpu_tensors.size());
+
+    DmlGpuEvent copy_event;
+
+    for (int i = 0; i < device_tensors.size(); ++i) {
+        const Tensor& device_tensor = device_tensors[i];
+        Tensor& cpu_tensor = cpu_tensors[i];
+
+        size_t total_bytes = cpu_tensor.TotalBytes();
+        if (total_bytes == 0)
+        {
+            continue;
+        }
+
+        D3D12BufferRegion src = GetBufferForTensor(device_tensor);
+        void* dst_data = cpu_tensor.base<void>();
+
+        // Performs a blocking call to synchronize and read back data from the GPU
+        // into the destination buffer
+        auto byte_span =
+            absl::Span<uint8_t>(static_cast<uint8_t*>(dst_data), total_bytes);
+
+        StatusOr<DmlGpuEvent> status_or_event =
+            readback_heap_->ReadbackFromGpu(byte_span, src);
+
+        if (!status_or_event.ok())
+        {
+            return status_or_event.status();
+        }
+
+        copy_event = status_or_event.ConsumeValueOrDie();
+    }
+
+    TF_RETURN_IF_ERROR(device->Sync());
+    copy_event.WaitForSignal();
+    return Status::OK();
+}
+
 Status DMLDeviceContext::CopyCPUMemoryToDevice(
     DmlDevice* device,
     const void* cpu_memory,

--- a/tfdml/core/dml_device_context.h
+++ b/tfdml/core/dml_device_context.h
@@ -76,6 +76,11 @@ class DMLDeviceContext
         const Tensor* device_tensor,
         Tensor* cpu_tensor);
 
+    Status CopyDeviceTensorsToCPU(
+        DmlDevice* device,
+        absl::Span<const Tensor> device_tensors,
+        absl::Span<Tensor> cpu_tensors);
+
     Status CopyCPUMemoryToDevice(
         DmlDevice* device,
         const void* cpu_memory,

--- a/tfdml/kernels/dml_segment_reduction_ops.cc
+++ b/tfdml/kernels/dml_segment_reduction_ops.cc
@@ -36,18 +36,7 @@ class DmlUnsortedSegmentReductionKernel : public OpKernel
         Status status;
         eager_context_ = TFE_NewContext(context_options, status.raw());
         OP_REQUIRES_OK(ctx, status);
-    }
 
-    ~DmlUnsortedSegmentReductionKernel() override
-    {
-        if (eager_context_)
-        {
-            TFE_DeleteContext(eager_context_);
-        }
-    }
-
-    void Compute(OpKernelContext* ctx)
-    {
         const char* operator_type = nullptr;
         switch (reduce_function)
         {
@@ -71,84 +60,86 @@ class DmlUnsortedSegmentReductionKernel : public OpKernel
                     "Unsupported segment reduction function."));
         }
 
-        Status status;
-        TFE_Op* unsorted_segment_op =
+        unsorted_segment_op_ =
             TFE_NewOp(eager_context_, operator_type, status.raw());
         OP_REQUIRES_OK(ctx, status);
-        auto unsorted_segment_op_cleanup = absl::MakeCleanup(
-            [unsorted_segment_op] { TFE_DeleteOp(unsorted_segment_op); });
 
-        TFE_OpSetDevice(unsorted_segment_op, "/device:CPU", status.raw());
+        TFE_OpSetDevice(unsorted_segment_op_, "/device:CPU", status.raw());
         OP_REQUIRES_OK(ctx, status);
+    }
 
-        // data_tensor is originally on the GPU, so copy it over to the CPU
-        // before executing the CPU operator
-        const Tensor& data_tensor = ctx->input(0);
-        Tensor data_tensor_cpu;
-        OP_REQUIRES_OK(
-            ctx,
-            ctx->allocate_temp(
-                data_tensor.dtype(),
-                data_tensor.shape(),
-                &data_tensor_cpu,
-                true));
-        OP_REQUIRES_OK(
-            ctx,
-            ctx->device()->CopyDeviceTensorToCPU(
-                &data_tensor,
-                &data_tensor_cpu));
-        TFE_TensorHandle* data_handle =
-            TFE_NewTensorHandle(data_tensor_cpu.raw(), status.raw());
-        OP_REQUIRES_OK(ctx, status);
-        auto input_handle_cleanup = absl::MakeCleanup(
-            [data_handle] { TFE_DeleteTensorHandle(data_handle); });
-        TFE_OpAddInput(unsorted_segment_op, data_handle, status.raw());
-        OP_REQUIRES_OK(ctx, status);
+    ~DmlUnsortedSegmentReductionKernel() override
+    {
+        TFE_DeleteOp(unsorted_segment_op_);
+        TFE_DeleteContext(eager_context_);
+    }
 
-        // segment_ids is originally on the GPU, so copy it over to the CPU
-        // before executing the CPU operator
-        const Tensor& segment_ids_tensor = ctx->input(1);
-        Tensor segment_ids_tensor_cpu;
+    void Compute(OpKernelContext* ctx)
+    {
+        // data and segment_ids are originally on the GPU, so copy them over to
+        // the CPU before executing the CPU operator
+        absl::InlinedVector<Tensor, 3> dml_tensors = {
+            ctx->input(0),
+            ctx->input(1),
+        };
+        absl::InlinedVector<Tensor, 3> cpu_tensors;
+
+        for (int i = 0; i < dml_tensors.size(); ++i)
+        {
+            const Tensor& input_tensor = dml_tensors[i];
+            Tensor input_tensor_cpu;
+            OP_REQUIRES_OK(
+                ctx,
+                ctx->allocate_temp(
+                    input_tensor.dtype(),
+                    input_tensor.shape(),
+                    &input_tensor_cpu,
+                    true));
+
+            cpu_tensors.push_back(std::move(input_tensor_cpu));
+        }
+
         OP_REQUIRES_OK(
             ctx,
-            ctx->allocate_temp(
-                segment_ids_tensor.dtype(),
-                segment_ids_tensor.shape(),
-                &segment_ids_tensor_cpu,
-                true));
-        OP_REQUIRES_OK(
-            ctx,
-            ctx->device()->CopyDeviceTensorToCPU(
-                &segment_ids_tensor,
-                &segment_ids_tensor_cpu));
-        TFE_TensorHandle* segment_ids_handle =
-            TFE_NewTensorHandle(segment_ids_tensor_cpu.raw(), status.raw());
-        OP_REQUIRES_OK(ctx, status);
-        auto segment_ids_handle_cleanup =
-            absl::MakeCleanup([segment_ids_handle]
-                              { TFE_DeleteTensorHandle(segment_ids_handle); });
-        TFE_OpAddInput(unsorted_segment_op, segment_ids_handle, status.raw());
-        OP_REQUIRES_OK(ctx, status);
+            ctx->device()->CopyDeviceTensorsToCPU(
+                dml_tensors,
+                absl::Span<Tensor>(cpu_tensors)));
 
         // num_segments is already on the CPU
-        const Tensor& num_segments_tensor = ctx->input(2);
-        TFE_TensorHandle* num_segments_handle =
-            TFE_NewTensorHandle(num_segments_tensor.raw(), status.raw());
-        OP_REQUIRES_OK(ctx, status);
-        auto num_segments_handle_cleanup =
-            absl::MakeCleanup([num_segments_handle]
-                              { TFE_DeleteTensorHandle(num_segments_handle); });
-        TFE_OpAddInput(unsorted_segment_op, num_segments_handle, status.raw());
-        OP_REQUIRES_OK(ctx, status);
+        cpu_tensors.push_back(ctx->input(2));
+
+        absl::InlinedVector<TFE_TensorHandle*, 3> handles;
+        auto handles_cleanup = absl::MakeCleanup(
+            [&handles]
+            {
+                for (TFE_TensorHandle* handle : handles)
+                {
+                    TFE_DeleteTensorHandle(handle);
+                }
+            });
+
+        Status status;
+        for (const Tensor& cpu_tensor : cpu_tensors)
+        {
+            TFE_TensorHandle* handle =
+                TFE_NewTensorHandle(cpu_tensor.raw(), status.raw());
+            OP_REQUIRES_OK(ctx, status);
+            handles.push_back(handle);
+
+            TFE_OpAddInput(unsorted_segment_op_, handle, status.raw());
+            OP_REQUIRES_OK(ctx, status);
+        }
 
         TFE_TensorHandle* output_handle = nullptr;
+        TFE_TensorHandle** output_handle_ptr = &output_handle;
         OP_REQUIRES_OK(ctx, status);
-        auto output_handle_cleanup = absl::MakeCleanup(
-            [output_handle] { TFE_DeleteTensorHandle(output_handle); });
+        auto output_handle_cleanup =
+            absl::MakeCleanup([output_handle_ptr]
+                              { TFE_DeleteTensorHandle(*output_handle_ptr); });
 
         int num_retvals = 1;
         TFE_Execute(
-            unsorted_segment_op,
+            unsorted_segment_op_,
             &output_handle,
             &num_retvals,
             status.raw());
@@ -170,6 +161,7 @@ class DmlUnsortedSegmentReductionKernel : public OpKernel
 
   private:
     TFE_Context* eager_context_ = nullptr;
+    TFE_Op* unsorted_segment_op_ = nullptr;
 };
 
 #define REGISTER_GPU_KERNEL_UNSORTEDSEGMENT(                                   \

--- a/tfdml/runtime_adapter/device.h
+++ b/tfdml/runtime_adapter/device.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include "absl/types/span.h"
 #include "tfdml/runtime_adapter/status.h"
 
 namespace tfdml
@@ -33,6 +34,10 @@ class Device
     virtual Status CopyDeviceTensorToCPU(
         const Tensor* device_tensor,
         Tensor* cpu_tensor) = 0;
+
+    virtual Status CopyDeviceTensorsToCPU(
+        absl::Span<const Tensor> device_tensors,
+        absl::Span<Tensor> cpu_tensors) = 0;
 
     virtual void CopyTensorInSameDevice(
         const Tensor* input_tensor,


### PR DESCRIPTION
The RAII wrapper that we used to deallocate the output of the SegmentReduction ops that were run on the CPU through the Eager API wasn't actually deallocating the memory because we were passing a pointer that was always null. To fix this, we needed to pass a pointer to the pointer (`TFE_TensorHandle**`).

There's also a slight performance increase by adding the `CopyDeviceTensorsToCPU` function which allows kernels to copy more than one tensor at once and flush/sync only once, instead of doing it twice.