### PR TITLE
Fix memory leak in StridedSlice

### DIFF
--- a/tfdml/kernels/dml_strided_slice_op.cc
+++ b/tfdml/kernels/dml_strided_slice_op.cc
@@ -1522,9 +1522,11 @@ class DmlStridedSliceCpuKernel : public OpKernel
         OP_REQUIRES_OK(ctx, status);
 
         TFE_TensorHandle* output_handle = nullptr;
+        TFE_TensorHandle** output_handle_ptr = &output_handle;
         OP_REQUIRES_OK(ctx, status);
-        auto output_handle_cleanup = absl::MakeCleanup(
-            [output_handle] { TFE_DeleteTensorHandle(output_handle); });
+        auto output_handle_cleanup =
+            absl::MakeCleanup([output_handle_ptr]
+                              { TFE_DeleteTensorHandle(*output_handle_ptr); });
 
         int num_retvals = 1;
         TFE_Execute(


### PR DESCRIPTION
The RAII wrapper that we used to deallocate the output of the StridedSlice op that was run on the CPU through the Eager API wasn't actually deallocating the memory because we were passing a pointer that was always null. To fix this, we needed to pass a pointer to the pointer (`TFE_TensorHandle**`).