### PR TITLE
Add int32 CPU implementation for Pack

### DIFF
--- a/tfdml/kernels/dml_pack_op.cc
+++ b/tfdml/kernels/dml_pack_op.cc
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "absl/cleanup/cleanup.h"
+#include "tensorflow/c/eager/c_api.h"
 #include "tfdml/kernels/pch.h"
 
 namespace tfdml
@@ -193,7 +195,88 @@ class DmlPackKernel : public DmlKernel
     }
 };
 
-void RegisterKernels_Pack()
+class DmlPackCpuKernel : public OpKernel
+{
+  public:
+    explicit DmlPackCpuKernel(
+        OpKernelConstruction* ctx,
+        std::shared_ptr<const NodeDef> node_def)
+        : OpKernel(std::move(node_def))
+    {
+        TFE_ContextOptions* context_options = TFE_NewContextOptions();
+        auto context_options_cleanup = absl::MakeCleanup(
+            [context_options] { TFE_DeleteContextOptions(context_options); });
+
+        Status status;
+        eager_context_ = TFE_NewContext(context_options, status.raw());
+        OP_REQUIRES_OK(ctx, status);
+
+        pack_op_ = TFE_NewOp(eager_context_, "Pack", status.raw());
+        OP_REQUIRES_OK(ctx, status);
+    }
+
+    ~DmlPackCpuKernel() override
+    {
+        TFE_DeleteOp(pack_op_);
+        TFE_DeleteContext(eager_context_);
+    }
+
+    void Compute(OpKernelContext* ctx)
+    {
+        Status status;
+        TFE_OpSetDevice(pack_op_, "/device:CPU", status.raw());
+        OP_REQUIRES_OK(ctx, status);
+
+        std::vector<TFE_TensorHandle*> input_handles;
+        auto input_handles_cleanup = absl::MakeCleanup(
+            [&input_handles]
+            {
+                for (TFE_TensorHandle* input_handle : input_handles)
+                {
+                    TFE_DeleteTensorHandle(input_handle);
+                }
+            });
+
+        for (int i = 0; i < ctx->num_inputs(); ++i)
+        {
+            const Tensor& input_tensor = ctx->input(i);
+            TFE_TensorHandle* input_handle =
+                TFE_NewTensorHandle(input_tensor.raw(), status.raw());
+            OP_REQUIRES_OK(ctx, status);
+            input_handles.push_back(input_handle);
+        }
+
+        TFE_OpAddInputList(
+            pack_op_,
+            input_handles.data(),
+            input_handles.size(),
+            status.raw());
+        OP_REQUIRES_OK(ctx, status);
+
+        TFE_TensorHandle* output_handle = nullptr;
+        TFE_TensorHandle** output_handle_ptr = &output_handle;
+        OP_REQUIRES_OK(ctx, status);
+        auto output_handle_cleanup =
+            absl::MakeCleanup([output_handle_ptr]
+                              { TFE_DeleteTensorHandle(*output_handle_ptr); });
+
+        int num_retvals = 1;
+        TFE_Execute(pack_op_, &output_handle, &num_retvals, status.raw());
+        OP_REQUIRES_OK(ctx, status);
+
+        TF_Tensor* output =
+            TFE_TensorHandleResolve(output_handle, status.raw());
+        OP_REQUIRES_OK(ctx, status);
+
+        OP_REQUIRES_OK(ctx, ctx->set_output(0, Tensor(output)));
+    }
+
+  private:
+    TFE_Context* eager_context_ = nullptr;
+    TFE_Op* pack_op_ = nullptr;
+};
+
+void RegisterPack()
 {
     using K = KernelDefinition<
         ops::Pack,
@@ -207,6 +290,20 @@ void RegisterKernels_Pack()
         TF_INT64,
         TF_INT16,
         TF_BOOL>();
+}
+
+void RegisterPackCpu()
+{
+    KernelDefinition<ops::Pack, DmlPackCpuKernel>::WithHostMemoryArguments<
+        ops::Pack::Argument::values,
+        ops::Pack::Argument::output>::
+        WithTypeConstraint<ops::Pack::Attribute::T, TF_INT32>::Register();
+}
+
+void RegisterKernels_Pack()
+{
+    RegisterPack();
+    RegisterPackCpu();
 }
 
 } // namespace tfdml


### PR DESCRIPTION
Pack unfortunately still doesn't have a `DEVICE_DEFAULT` registration in TensorFlow Core, so we're force to register it here ourselves.