### PR TITLE
Fix memory leak in the emulated philox random kernels

### DIFF
--- a/tfdml/kernels/dml_random_ops.cc
+++ b/tfdml/kernels/dml_random_ops.cc
@@ -661,9 +661,11 @@ class DmlEmulatedPhiloxRandomKernel : public OpKernel
         OP_REQUIRES_OK(ctx, status);
 
         TFE_TensorHandle* output_handle = nullptr;
+        TFE_TensorHandle** output_handle_ptr = &output_handle;
         OP_REQUIRES_OK(ctx, status);
-        auto output_handle_cleanup = absl::MakeCleanup(
-            [output_handle] { TFE_DeleteTensorHandle(output_handle); });
+        auto output_handle_cleanup =
+            absl::MakeCleanup([output_handle_ptr]
+                              { TFE_DeleteTensorHandle(*output_handle_ptr); });
 
         int num_retvals = 1;
         TFE_Execute(random_op, &output_handle, &num_retvals, status.raw());


### PR DESCRIPTION
The RAII wrapper that we used to deallocate the output of the emulated philox random kernels that were run on the CPU through the Eager API wasn't actually deallocating the memory because we were passing a pointer that was always null. To fix this, we needed to pass a pointer to the pointer (`TFE_TensorHandle**`).