### PR TITLE
Fix InTopKV2 crash when k > dim_size(axis)

### DIFF
--- a/tfdml/kernels/dml_in_topk_op.cc
+++ b/tfdml/kernels/dml_in_topk_op.cc
@@ -80,12 +80,14 @@ class DmlInTopKKernel : public DmlKernel
         DmlKernelConstruction* ctx,
         const InitHelper* init_helper)
     {
+        const auto predictions_shape = ctx->GetInputTensorShape(0);
+
         DmlTensorInfo predictions_info;
         predictions_info.kernel_index = 0;
         predictions_info.desc = DmlTensorDesc::Create(
             ctx->GetInputDataType(0),
-            ctx->GetInputTensorShape(0),
-            ctx->GetInputTensorShape(0));
+            predictions_shape,
+            predictions_shape);
 
         DmlTensorInfo targets_info;
         targets_info.kernel_index = 1;
@@ -107,6 +109,12 @@ class DmlInTopKKernel : public DmlKernel
         tensors.outputs = {output_info};
 
         int64_t k = init_helper->GetK();
+
+        // DML doesn't support K values bigger than the size of the TopK axis,
+        // so clamp it to the maximum
+        k = std::min<int64_t>(
+            k,
+            predictions_shape.dim_size(predictions_shape.dims() - 1));
 
         // When K is smaller than 1, none of the targets are in the top K
         if (k < 1)


### PR DESCRIPTION
DML doesn't support K values that are bigger than the dimension size of the axis being checked.