### PR TITLE
Add missing kernel profiling

### DIFF
--- a/tfdml/core/dml_device.cc
+++ b/tfdml/core/dml_device.cc
@@ -152,4 +152,19 @@ DMLDeviceContext* DmlDevice::GetDeviceContext() const
     return device_context_.get();
 }
 
+absl::optional<uint32_t> DmlDevice::TryLogKernelComputeStart(
+    const absl::string_view type,
+    const absl::string_view name) const
+{
+    return DmlTracing::Instance().TryLogKernelComputeStart(
+        device_ordinal_,
+        type,
+        name);
+}
+
+void DmlDevice::LogKernelComputeEnd(uint32_t event_id) const
+{
+    DmlTracing::Instance().LogKernelComputeEnd(device_ordinal_, event_id);
+}
+
 } // namespace tfdml

--- a/tfdml/core/dml_device.h
+++ b/tfdml/core/dml_device.h
@@ -53,6 +53,12 @@ class DmlDevice : public Device
     Status Sync();
     inline uint32_t GetDeviceOrdinal() const { return device_ordinal_; }
 
+    absl::optional<uint32_t> TryLogKernelComputeStart(
+        const absl::string_view type,
+        const absl::string_view name) const final;
+
+    void LogKernelComputeEnd(uint32_t event_id) const final;
+
     void CopyTensorInSameDevice(
         const Tensor* input_tensor,
         Tensor* output_tensor) final;

--- a/tfdml/core/dml_kernel_wrapper.cc
+++ b/tfdml/core/dml_kernel_wrapper.cc
@@ -32,14 +32,9 @@ DmlKernelWrapperBase::DmlKernelWrapperBase(
 {
 }
 
-void DmlKernelWrapperBase::Compute(OpKernelContext* ctx)
+void DmlKernelWrapperBase::ComputeImpl(OpKernelContext* ctx)
 {
     DmlDevice* dml_device = static_cast<DmlDevice*>(ctx->device());
-
-    DmlTracing::KernelComputeEventScope event_scope(
-        dml_device->GetDeviceOrdinal(),
-        ctx->op_kernel().type_string(),
-        ctx->op_kernel().name());
 
     const DmlKernelManager& kernel_manager = *dml_device->GetKernelManager();
 

--- a/tfdml/core/dml_kernel_wrapper.h
+++ b/tfdml/core/dml_kernel_wrapper.h
@@ -48,8 +48,6 @@ class DmlKernelWrapperBase : public OpKernel
         std::shared_ptr<const NodeDef> node_def);
     virtual ~DmlKernelWrapperBase() = default;
 
-    void Compute(OpKernelContext* raw_ctx);
-
   protected:
     virtual const ShapeHelper* GetShapeHelper() const = 0;
     virtual std::shared_ptr<const InitializationHelper>
@@ -80,6 +78,9 @@ class DmlKernelWrapperBase : public OpKernel
     virtual DmlKernelKey CreateKernelKey(OpKernelContext* ctx) const;
 
     DmlKernelCachePolicy cache_policy_;
+
+  private:
+    void ComputeImpl(OpKernelContext* raw_ctx) final;
 };
 
 // Implements a (templated) GetOrCreateKernel and output shape computation for

--- a/tfdml/core/dml_tracing.h
+++ b/tfdml/core/dml_tracing.h
@@ -45,41 +45,6 @@ class DmlTracing
         Verbose = 2,
     };
 
-    // Pair of IDs for the device and event within that device.
-    struct ProfilerEventId
-    {
-        size_t device_id;
-        size_t event_id;
-    };
-
-    // RAII helper to track a DML kernel compute call on the CPU timeline.
-    class KernelComputeEventScope
-    {
-        // This event will be null if the TF profiler isn't active when the
-        // scope is constructed.
-        absl::optional<ProfilerEventId> device_event_id;
-
-      public:
-        KernelComputeEventScope(
-            uint32_t device_id,
-            const absl::string_view type,
-            const absl::string_view name)
-        {
-            device_event_id = DmlTracing::Instance().TryLogKernelComputeStart(
-                device_id,
-                type,
-                name);
-        }
-
-        ~KernelComputeEventScope()
-        {
-            if (device_event_id)
-            {
-                DmlTracing::Instance().LogKernelComputeEnd(*device_event_id);
-            }
-        }
-    };
-
   private:
     DmlTracing();
     ~DmlTracing();
@@ -126,11 +91,11 @@ class DmlTracing
     void LogExecutionContextCopyBufferRegion();
     void LogExecutionContextFillBufferWithPattern();
     void LogExecutionContextFlush();
-    absl::optional<ProfilerEventId> TryLogKernelComputeStart(
+    absl::optional<uint32_t> TryLogKernelComputeStart(
         uint32_t device_ordinal,
         const absl::string_view op_type,
         const absl::string_view op_name);
-    void LogKernelComputeEnd(const ProfilerEventId& id);
+    void LogKernelComputeEnd(uint32_t device_id, uint32_t event_id);
 
     // GPU timeline
     void LogExecuteOperatorStart(

--- a/tfdml/kernels/dml_addn_op.cc
+++ b/tfdml/kernels/dml_addn_op.cc
@@ -226,7 +226,8 @@ class DmlBinaryAddVariantKernelWrapper : public OpKernel
             key);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         DmlDevice* dml_device = static_cast<DmlDevice*>(ctx->device());
 
@@ -308,7 +309,6 @@ class DmlBinaryAddVariantKernelWrapper : public OpKernel
         return key;
     }
 
-  private:
     std::shared_ptr<NodeDef> node_def_;
     DmlDevice* dml_device_;
     const Tensor* a_tensor_;
@@ -377,7 +377,8 @@ class DmlAddNVariantKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         OP_REQUIRES_OK(ctx, ctx->AddNVariant(BinaryAddVariant));
     }

--- a/tfdml/kernels/dml_assign_variable_op.cc
+++ b/tfdml/kernels/dml_assign_variable_op.cc
@@ -37,7 +37,8 @@ class DmlAssignVariableOp : public OpKernel
         }
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         constexpr int var_index = 0;
         constexpr int value_index = 1;
@@ -56,7 +57,6 @@ class DmlAssignVariableOp : public OpKernel
             ctx->AssignVariable(var_index, value_index, validate_shape_));
     }
 
-  private:
     TF_DataType dtype_;
     bool validate_shape_ = false;
 };
@@ -77,7 +77,8 @@ class DmlAssign : public OpKernel
             context->GetAttr("validate_shape", &validate_shape_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         constexpr int input_ref_index = 0;
         constexpr int output_ref_index = 0;
@@ -93,7 +94,6 @@ class DmlAssign : public OpKernel
                 validate_shape_));
     }
 
-  private:
     bool exclusive_lock_;
     bool validate_shape_;
 };
@@ -304,7 +304,8 @@ class DmlUpdateVariableOp : public OpKernel
         OP_REQUIRES_OK(c, c->GetAttr("dtype", &dtype_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         constexpr int var_index = 0;
         constexpr int value_index = 1;
@@ -316,7 +317,6 @@ class DmlUpdateVariableOp : public OpKernel
                 UpdateVariable<Expression>));
     }
 
-  private:
     TF_DataType dtype_;
 };
 

--- a/tfdml/kernels/dml_bitcast_op.cc
+++ b/tfdml/kernels/dml_bitcast_op.cc
@@ -29,7 +29,8 @@ class DmlBitcastKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& input = ctx->input(0);
         int dim_count = input.dims();

--- a/tfdml/kernels/dml_data_format_vec_permute.cc
+++ b/tfdml/kernels/dml_data_format_vec_permute.cc
@@ -102,7 +102,8 @@ class DmlDataFormatVecPermuteKernel : public OpKernel
         dst_format_ = dst_format;
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& input = ctx->input(0);
         const TensorShape& input_shape = input.shape();
@@ -235,7 +236,6 @@ class DmlDataFormatVecPermuteKernel : public OpKernel
         }
     }
 
-  private:
     std::string src_format_;
     std::string dst_format_;
 };

--- a/tfdml/kernels/dml_deepcopy_op.cc
+++ b/tfdml/kernels/dml_deepcopy_op.cc
@@ -29,7 +29,8 @@ class DmlDeepCopyKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& input = ctx->input(0);
         const TensorShape& input_shape = input.shape();

--- a/tfdml/kernels/dml_dynamic_stitch_op.cc
+++ b/tfdml/kernels/dml_dynamic_stitch_op.cc
@@ -54,7 +54,8 @@ class DmlDynamicStitchKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->GetAttr("N", &num_inputs_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         // Find maximum index in the indices vectors
         std::vector<Tensor> indices_inputs;
@@ -203,7 +204,6 @@ class DmlDynamicStitchKernel : public OpKernel
         }
     }
 
-  private:
     int32_t num_inputs_;
 };
 

--- a/tfdml/kernels/dml_empty_op.cc
+++ b/tfdml/kernels/dml_empty_op.cc
@@ -30,7 +30,8 @@ class DmlEmptyKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->GetAttr("init", &init_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& shape = ctx->input(0);
         OP_REQUIRES(
@@ -59,7 +60,6 @@ class DmlEmptyKernel : public OpKernel
         }
     }
 
-  private:
     bool init_;
 };
 

--- a/tfdml/kernels/dml_pack_op.cc
+++ b/tfdml/kernels/dml_pack_op.cc
@@ -228,7 +228,8 @@ class DmlPackCpuKernel : public OpKernel
         TFE_DeleteContext(eager_context_);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         std::vector<TFE_TensorHandle*> input_handles;
         auto input_handles_cleanup = absl::MakeCleanup(
@@ -275,7 +276,6 @@ class DmlPackCpuKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->set_output(0, Tensor(output)));
     }
 
-  private:
     TFE_Context* eager_context_ = nullptr;
     TFE_Op* pack_op_ = nullptr;
 };

--- a/tfdml/kernels/dml_parallel_concat_ops.cc
+++ b/tfdml/kernels/dml_parallel_concat_ops.cc
@@ -33,7 +33,8 @@ class DmlFailureKernel : public OpKernel
                              "could not be properly replaced."));
     }
 
-    void Compute(OpKernelContext*) {}
+  private:
+    void ComputeImpl(OpKernelContext*) final {}
 };
 
 class DmlParallelConcatStartKernel : public OpKernel
@@ -47,14 +48,14 @@ class DmlParallelConcatStartKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->GetAttr("shape", &shape_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         StatusOr<Tensor> status_or_output_tensor =
             ctx->allocate_output(0, shape_);
         OP_REQUIRES_OK(ctx, status_or_output_tensor.status());
     }
 
-  private:
     TensorShape shape_;
 };
 
@@ -69,7 +70,8 @@ class DmlParallelConcatUpdateKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->GetAttr("loc", &loc_));
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& value_tensor = ctx->input(0);
 
@@ -143,7 +145,6 @@ class DmlParallelConcatUpdateKernel : public OpKernel
         ctx->set_output(0, output_tensor);
     }
 
-  private:
     int32_t loc_;
 };
 

--- a/tfdml/kernels/dml_random_ops.cc
+++ b/tfdml/kernels/dml_random_ops.cc
@@ -952,7 +952,8 @@ class RandomUniformInt64KernelSelector : public OpKernel
         TFE_DeleteContext(eager_context_);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         int min_value_index = is_stateless ? 2 : 1;
         int max_value_index = is_stateless ? 3 : 2;
@@ -1078,7 +1079,6 @@ class RandomUniformInt64KernelSelector : public OpKernel
         }
     }
 
-  private:
     DmlRandomKernelWrapperImpl dml_kernel_wrapper_;
     int64_t seed_;
     int64_t seed2_;
@@ -1145,7 +1145,8 @@ class DmlEmulatedPhiloxRandomKernel : public OpKernel
         TFE_DeleteContext(eager_context_);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         Status status;
         const Tensor& shape_tensor = ctx->input(0);
@@ -1183,7 +1184,6 @@ class DmlEmulatedPhiloxRandomKernel : public OpKernel
             ctx->device()->CopyCPUTensorToDevice(&output_cpu, &output));
     }
 
-  private:
     TFE_Context* eager_context_ = nullptr;
     TFE_Op* random_op_ = nullptr;
 };
@@ -1427,7 +1427,8 @@ class GetKeyCounterAlgOp : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& seed_t = ctx->input(0);
         OP_REQUIRES(
@@ -1470,7 +1471,8 @@ class GetKeyCounterOp : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& seed_t = ctx->input(0);
         OP_REQUIRES(
@@ -1508,7 +1510,8 @@ class GetAlgOp : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         auto status_or_alg_output = ctx->allocate_output(0, TensorShape({}));
         OP_REQUIRES_OK(ctx, status_or_alg_output.status());

--- a/tfdml/kernels/dml_segment_reduction_ops.cc
+++ b/tfdml/kernels/dml_segment_reduction_ops.cc
@@ -74,7 +74,8 @@ class DmlUnsortedSegmentReductionKernel : public OpKernel
         TFE_DeleteContext(eager_context_);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         // data and segment_ids are originally on the GPU, so copy them over to
         // the CPU before executing the CPU operator
@@ -159,7 +160,6 @@ class DmlUnsortedSegmentReductionKernel : public OpKernel
             ctx->device()->CopyCPUTensorToDevice(&output_cpu, &output));
     }
 
-  private:
     TFE_Context* eager_context_ = nullptr;
     TFE_Op* unsorted_segment_op_ = nullptr;
 };

--- a/tfdml/kernels/dml_snapshot_op.cc
+++ b/tfdml/kernels/dml_snapshot_op.cc
@@ -28,7 +28,8 @@ class DmlSnapshotOp : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* context)
+  private:
+    void ComputeImpl(OpKernelContext* context) final
     {
         const Tensor& input = context->input(0);
         // Try to use buffer forwarding to avoid an explicit copy.

--- a/tfdml/kernels/dml_strided_slice_op.cc
+++ b/tfdml/kernels/dml_strided_slice_op.cc
@@ -1487,7 +1487,8 @@ class DmlStridedSliceCpuKernel : public OpKernel
         TFE_DeleteContext(eager_context_);
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         absl::InlinedVector<TFE_TensorHandle*, 4> input_handles;
         auto input_handles_cleanup = absl::MakeCleanup(
@@ -1534,7 +1535,6 @@ class DmlStridedSliceCpuKernel : public OpKernel
         OP_REQUIRES_OK(ctx, ctx->set_output(0, Tensor(output)));
     }
 
-  private:
     TFE_Context* eager_context_ = nullptr;
     TFE_Op* strided_slice_op_ = nullptr;
 };

--- a/tfdml/kernels/dml_swapping_ops.cc
+++ b/tfdml/kernels/dml_swapping_ops.cc
@@ -29,7 +29,8 @@ class DmlCopyFromGpuToHost : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& input = ctx->input(0);
         StatusOr<Tensor> status_or_output =
@@ -54,7 +55,8 @@ class DmlCopyFromHostToGpu : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         const Tensor& input = ctx->input(0);
         StatusOr<Tensor> status_or_output =

--- a/tfdml/kernels/dml_where_op.cc
+++ b/tfdml/kernels/dml_where_op.cc
@@ -150,7 +150,8 @@ class DmlWhereKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         Tensor input_tensor = ctx->input(0);
         OP_REQUIRES(

--- a/tfdml/kernels/dml_zeros_like_op.cc
+++ b/tfdml/kernels/dml_zeros_like_op.cc
@@ -40,7 +40,8 @@ class DmlZerosLikeKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         int candidate_input_indices[] = {0};
 
@@ -121,7 +122,8 @@ class DmlZerosLikeVariantKernel : public OpKernel
     {
     }
 
-    void Compute(OpKernelContext* ctx)
+  private:
+    void ComputeImpl(OpKernelContext* ctx) final
     {
         OP_REQUIRES_OK(ctx, ctx->ZerosLikeVariant(ZerosLikeVariant));
     }

--- a/tfdml/runtime_adapter/device.h
+++ b/tfdml/runtime_adapter/device.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #pragma once
 
+#include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "tfdml/runtime_adapter/status.h"
 
@@ -42,5 +43,11 @@ class Device
     virtual void CopyTensorInSameDevice(
         const Tensor* input_tensor,
         Tensor* output_tensor) = 0;
+
+    virtual absl::optional<uint32_t> TryLogKernelComputeStart(
+        const absl::string_view type,
+        const absl::string_view name) const = 0;
+
+    virtual void LogKernelComputeEnd(uint32_t event_id) const = 0;
 };
 } // namespace tfdml


### PR DESCRIPTION
We were previously only profiling compute for kernels wrapped by the `DmlKernelWrapperBase` class, but not all kernels do. Since some of the kernels inherit directly from `OpKernel`, the compute logging was moved up into `OpKernel::Compute` as well.