### PR TITLE
Compress linux framework into a .tar.gz instead of .zip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,12 @@ if(NOT WIN32)
     string(REGEX MATCH "#define DIRECTML_SOURCE_VERSION \"([abcdef0-9]+)\"" REGEX_MATCH ${DIRECTML_CONFIG})
     set(DIRECTML_SHA ${CMAKE_MATCH_1})
 
-    set(framework_full_name "${pkg_name}-${pkg_version}-${pkg_platform}.zip")
+    if(WIN32)
+        set(framework_full_name "${pkg_name}-${pkg_platform}-${pkg_version}.zip")
+    else()
+        set(framework_full_name "${pkg_name}-${pkg_platform}-${pkg_version}.tar.gz")
+    endif()
+
     add_custom_command(
         OUTPUT 
             ${framework_full_name}
@@ -594,7 +599,7 @@ if(NOT WIN32)
             $<$<BOOL:${WIN32}>:${pix_event_runtime_SOURCE_DIR}/ThirdPartyNotices.txt>
             $<$<BOOL:${WIN32}>:./directml/WinPixEventRuntime_ThirdPartyNotices.txt>
         COMMAND
-            ${CMAKE_COMMAND} -E tar "cfv" "${framework_full_name}" --format=zip --
+            ${CMAKE_COMMAND} -E tar $<$<BOOL:${WIN32}>:"cfv"> $<$<BOOL:${WIN32}>:"cfvz"> "${framework_full_name}" $<$<BOOL:${WIN32}>:--format=zip> --
             $<TARGET_FILE_NAME:tfdml_plugin_framework>
             LICENSE
             directml/DirectML_LICENSE.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,7 +599,7 @@ if(NOT WIN32)
             $<$<BOOL:${WIN32}>:${pix_event_runtime_SOURCE_DIR}/ThirdPartyNotices.txt>
             $<$<BOOL:${WIN32}>:./directml/WinPixEventRuntime_ThirdPartyNotices.txt>
         COMMAND
-            ${CMAKE_COMMAND} -E tar $<$<BOOL:${WIN32}>:"cfv"> $<$<BOOL:${WIN32}>:"cfvz"> "${framework_full_name}" $<$<BOOL:${WIN32}>:--format=zip> --
+            ${CMAKE_COMMAND} -E tar $<$<BOOL:${WIN32}>:"cfv"> $<$<BOOL:${UNIX}>:"cfvz"> "${framework_full_name}" $<$<BOOL:${WIN32}>:--format=zip> --
             $<TARGET_FILE_NAME:tfdml_plugin_framework>
             LICENSE
             directml/DirectML_LICENSE.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,9 +562,9 @@ if(NOT WIN32)
     set(DIRECTML_SHA ${CMAKE_MATCH_1})
 
     if(WIN32)
-        set(framework_full_name "${pkg_name}-${pkg_platform}-${pkg_version}.zip")
+        set(framework_full_name "${CMAKE_PROJECT_NAME}-${pkg_platform}-${pkg_version}.zip")
     else()
-        set(framework_full_name "${pkg_name}-${pkg_platform}-${pkg_version}.tar.gz")
+        set(framework_full_name "lib${CMAKE_PROJECT_NAME}-${pkg_platform}-${pkg_version}.tar.gz")
     endif()
 
     add_custom_command(

--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -136,6 +136,7 @@ jobs:
       New-Item -Force -ItemType Directory "$(buildPubPath)"
       Copy-Item -Recurse "$(buildOutPath)/*.whl" "$(buildPubPath)"
       Copy-Item -Recurse "$(buildOutPath)/*.zip" "$(buildPubPath)"
+      Copy-Item -Recurse "$(buildOutPath)/*.tar.gz" "$(buildPubPath)"
       Copy-Item -Recurse "$(Build.SourcesDirectory)/test" "$(buildPubPath)"
     displayName: Stage Artifacts
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
.tar.gz archives are the usual way to compress files on Linux, and it matches what the TensorFlow C API uses.