### PR TITLE
Add an interactive publish step for the release pipeline

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -177,26 +177,19 @@ stages:
     - job: publish
       displayName: Publish
       steps:
-      - task: DownloadBuildArtifacts@0
-        inputs:
-          buildType: current
-          downloadType: single
-          artifactName: artifacts
-          cleanDestinationFolder: true
-          itemPattern: |
-            x64-linux-release-cp*/*.whl
-            x64-win-release-cp*/*.whl
-            x64-linux-release-cp310/tensorflow_directml_plugin-*-linux_x86_64.zip
       - powershell: |
-          pip install twine
+          New-Item $(Build.ArtifactStagingDirectory)/pypi -ItemType Directory
+          Copy-Item $(Pipeline.Workspace)/x64-linux-release-cp*/*.whl $(Build.ArtifactStagingDirectory)/pypi -Force
+          Copy-Item $(Pipeline.Workspace)/x64-win-release-cp*/*.whl $(Build.ArtifactStagingDirectory)/pypi -Force
 
+          pip install twine
           if ("${{parameters.pypiTestUpload}}" -eq "True")
           {
-            twine upload --repository-url https://test.pypi.org/legacy/ --username="__token__" --password="$(pypiTestToken)" $(Build.ArtifactStagingDirectory)/artifacts/*.whl
+            twine upload --repository-url https://test.pypi.org/legacy/ --username="__token__" --password="$(pypiTestToken)" $(Build.ArtifactStagingDirectory)/pypi/*.whl
           }
           else
           {
-            twine upload --username="__token__" --password="$(pypiToken)" $(Build.ArtifactStagingDirectory)/artifacts/*.whl
+            twine upload --username="__token__" --password="$(pypiToken)" $(Build.ArtifactStagingDirectory)/pypi/*.whl
           }
         displayName: Upload wheels to PyPI
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/user/pavignol/'))

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -25,6 +25,9 @@ parameters:
   displayName: Release Build
   type: boolean
   default: false
+- name: pypiTestUpload
+  type: boolean
+  default: false
 
 # Uploads artifacts to blob storage to be ushered to network share. Generally this should only be enabled for main
 # and release branches.
@@ -155,3 +158,44 @@ stages:
       parameters:
         emailTo: ${{parameters.emailTo}}
         enableTests: ${{parameters.enableTests}}
+
+  - stage: publishStage
+    displayName: Publish
+    pool: DirectML_TF2_Windows_Pool
+    jobs:
+    - job: waitForValidation
+      displayName: Wait for external validation
+      timeoutInMinutes: 1440 # job times out in 1 day
+      steps:
+      - task: ManualValidation@0
+        inputs:
+          notifyUsers: |
+            pavignol@microsoft.com
+          instructions: 'If the test results look good, resume the pipeline to publish to PyPI and GitHub releases'
+          onTimeout: 'resume'
+    - job: publish
+      displayName: Publish
+      steps:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: current
+          downloadType: single
+          artifactName: artifacts
+          cleanDestinationFolder: true
+          itemPattern: |
+            x64-linux-release-cp*/*.whl
+            x64-win-release-cp*/*.whl
+            x64-linux-release-cp310/tensorflow_directml_plugin-*-linux_x86_64.zip
+      - powershell: |
+          pip install twine
+
+          if ("${{parameters.pypiTestUpload}}" -eq "True")
+          {
+            twine upload --repository-url https://test.pypi.org/legacy/ --username="__token__" --password="$(pypiTestToken)" $(Build.ArtifactStagingDirectory)/artifacts/*.whl
+          }
+          else
+          {
+            twine upload --username="__token__" --password="$(pypiToken)"
+          }
+        displayName: Upload wheels to PyPI
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'releases/'))

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -197,4 +197,4 @@ stages:
             twine upload --username="__token__" --password="$(pypiToken)" $(Build.ArtifactStagingDirectory)/pypi/*.whl
           }
         displayName: Upload wheels to PyPI
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/user/pavignol/'))
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release/'))

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -199,4 +199,4 @@ stages:
             twine upload --username="__token__" --password="$(pypiToken)" $(Build.ArtifactStagingDirectory)/artifacts/*.whl
           }
         displayName: Upload wheels to PyPI
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'user/pavignol/'))
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/user/pavignol/'))

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -171,8 +171,8 @@ stages:
       - task: ManualValidation@0
         inputs:
           notifyUsers: |
-            pavignol@microsoft.com
-          instructions: 'If the test results look good, resume the pipeline to publish to PyPI and GitHub releases'
+            $(emailTo)
+          instructions: 'If the test results look good, resume the pipeline to publish to PyPI'
           onTimeout: 'resume'
     - job: publish
       displayName: Publish

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -196,7 +196,7 @@ stages:
           }
           else
           {
-            twine upload --username="__token__" --password="$(pypiToken)"
+            twine upload --username="__token__" --password="$(pypiToken)" $(Build.ArtifactStagingDirectory)/artifacts/*.whl
           }
         displayName: Upload wheels to PyPI
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'user/pavignol/'))

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -176,7 +176,12 @@ stages:
           onTimeout: 'resume'
     - job: publish
       displayName: Publish
+      dependsOn: waitForValidation
       steps:
+      - ${{each artifact in parameters.buildArtifacts}}:
+        - download: 'current'
+          artifact: ${{artifact}}
+          displayName: Download ${{artifact}}
       - powershell: |
           New-Item $(Build.ArtifactStagingDirectory)/pypi -ItemType Directory
           Copy-Item $(Pipeline.Workspace)/x64-linux-release-cp*/*.whl $(Build.ArtifactStagingDirectory)/pypi -Force

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -164,6 +164,7 @@ stages:
     pool: DirectML_TF2_Windows_Pool
     jobs:
     - job: waitForValidation
+      pool: server
       displayName: Wait for external validation
       timeoutInMinutes: 1440 # job times out in 1 day
       steps:
@@ -198,4 +199,4 @@ stages:
             twine upload --username="__token__" --password="$(pypiToken)"
           }
         displayName: Upload wheels to PyPI
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'releases/'))
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'user/pavignol/'))


### PR DESCRIPTION
We'll now be able to upload to PyPI directly from the pipeline, instead of having to download the wheels locally and running twine. This will be much less error prone.