### PR TITLE
update TensorFlow dependency version to 2.12.0

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -72,7 +72,7 @@ Once you've installed Miniconda you will want to create and activate a Python 3.
 Download the latest [Miniconda3 Windows 64-bit](https://docs.conda.io/en/latest/miniconda.html) installer. You can leave all the default settings.
 
 ```
-conda create --name tfdml_plugin python=3.7
+conda create --name tfdml_plugin python=3.9
 conda activate tfdml_plugin
 pip install wheel vswhere
 ```

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -21,25 +21,25 @@ set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests")
 # TensorFlow python package
 if(WIN32)
     # To update the package version to a nightly build, go to https://pypi.org/project/tf-nightly-intel/#files and copy the
-    # URLs and SHA256 hashes for the cp37 versions. For stable builds, go to https://pypi.org/project/tensorflow-intel/#files instead.
+    # URLs and SHA256 hashes for the cp39 versions. For stable builds, go to https://pypi.org/project/tensorflow-intel/#files instead.
     FetchContent_Declare(
         tensorflow_whl
-        URL https://files.pythonhosted.org/packages/4c/57/3b37cf30bf1549e617f8328c10b1f3237bf50c9ac7be3de6fcb4c73a19ef/tensorflow_intel-2.12.0rc0-cp39-cp39-win_amd64.whl
-        URL_HASH SHA256=4f6793e0d9238b2fd57f10f39d7b3ab38000e2fca3144c260f581665be35a971
+        URL https://files.pythonhosted.org/packages/36/5b/401b3eb4b0af7f7a261689255b9944c0d7266eb528b12fe6a6df20b0796c/tensorflow_intel-2.12.0-cp39-cp39-win_amd64.whl
+        URL_HASH SHA256=2c3ece439d589362374d6e9f7775d2fac4591e0d9fc22a431f2eeaa4a0d2994a
     )
 
     FetchContent_Declare(
         tensorflow_framework
-        URL https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-windows-x86_64-2.10.0.zip
-        URL_HASH SHA256=4c5e6f9a7683583220716fecadea53ace233f31f59062e83585c4821f9968438
+        URL https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-windows-x86_64-2.12.0.zip
+        URL_HASH SHA256=bbb6c123247104e766437577ce42b426bf14234cd839114e4223fe5e56cc1b99
     )
 else()
     # To update the package version to a nightly build, go to https://pypi.org/project/tf-nightly-cpu/#files and copy the
-    # URLs and SHA256 hashes for the cp37 versions. For stable builds, go to https://pypi.org/project/tensorflow-cpu/#files instead.
+    # URLs and SHA256 hashes for the cp39 versions. For stable builds, go to https://pypi.org/project/tensorflow-cpu/#files instead.
     FetchContent_Declare(
         tensorflow_whl
-        URL https://files.pythonhosted.org/packages/61/f7/5888bb138d8ae9c6400996c3f0ffc2d9034c5213d7c6aa6deea79bbfe2c3/tensorflow_cpu-2.12.0rc0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        URL_HASH SHA256=505921b47561f7b26fef8d1e5d781c4afd9aaba8945b02258d36037f70cdfbef
+        URL https://files.pythonhosted.org/packages/6a/d8/137fd38cf5572c8aa11a05ea0f255675299ce299c2967c40f2ae2fea19ad/tensorflow_cpu-2.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        URL_HASH SHA256=55685b9a19c8ecb2587fb53914c045b188ed0289a2c6495e4e59d5fb082da9cc
     )
 
     FetchContent_Declare(
@@ -228,7 +228,7 @@ tf_proto_cpp(tensorflow/tsl/profiler/protobuf/xplane.proto)
 
 # A python interpreter is required to produce the plugin wheel. This python environment
 # must have the 'wheel' package installed.
-find_package(Python 3.6 COMPONENTS Interpreter REQUIRED)
+find_package(Python 3.9 COMPONENTS Interpreter REQUIRED)
 
 execute_process(
     COMMAND "${Python_EXECUTABLE}" "-c" "import wheel"

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -74,12 +74,12 @@ parameters:
 - name: testTensorflowVersion
   displayName: TensorFlow Package Version
   type: string
-  default: 2.12.0rc0
+  default: 2.12.0
 
 - name: testKerasPackage
   displayName: Keras Package Version
   type: string
-  default: keras==2.12.0rc0
+  default: keras==2.12.0
 
 - name: enableTests
   displayName: Enable Tests

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -19,10 +19,10 @@ parameters:
   default: [tensorflow-cpu]
 - name: tensorflowVersion
   type: string
-  default: 2.12.0rc0
+  default: 2.12.0
 - name: kerasPackage
   type: string
-  default: keras==2.12.0rc0
+  default: keras==2.12.0
 - name: pluginBuildPipeline
   type: string
   default: current

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==22.6.0
 pylint==2.14.5
 tensorboard_plugin_profile==2.8.0
-tensorflow-cpu==2.12.0rc0
+tensorflow-cpu==2.12.0
 vswhere==1.4.0 ; sys_platform == 'win32'
 portpicker==1.5.2

--- a/tfdml/wheel/setup.py
+++ b/tfdml/wheel/setup.py
@@ -40,7 +40,7 @@ _PLUGIN_LIB_PATH = "tensorflow-plugins"
 _MY_PLUGIN_PATH = "tensorflow-directml-plugin"
 
 REQUIRED_PACKAGES = [
-    "tensorflow-cpu == 2.12.0rc0",
+    "tensorflow-cpu == 2.12.0",
 ]
 
 if sys.byteorder == "little":
@@ -54,17 +54,7 @@ with open("TFDML_WHEEL_NAME", "r", encoding="utf-8") as f:
     project_name = f.read()
 
 # python3 requires wheel 0.26
-if sys.version_info.major == 3:
-    REQUIRED_PACKAGES.append("wheel >= 0.26")
-else:
-    REQUIRED_PACKAGES.append("wheel")
-    # mock comes with unittest.mock for python3, need to install for python2
-    REQUIRED_PACKAGES.append("mock >= 2.0.0")
-
-# weakref.finalize and enum were introduced in Python 3.4
-if sys.version_info < (3, 4):
-    REQUIRED_PACKAGES.append("backports.weakref >= 1.0rc1")
-    REQUIRED_PACKAGES.append("enum34 >= 1.1.6")
+REQUIRED_PACKAGES.append("wheel >= 0.26")
 
 # pylint: disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
Fixes #354.

 * 2.12.0rc0 -> 2.12.0
 * bump references from python 3.7 to 3.9
 * remove old code (pre-python 3.4)
